### PR TITLE
Is this a good idea yes/no?

### DIFF
--- a/sdk/plugins/output.cpp
+++ b/sdk/plugins/output.cpp
@@ -44,6 +44,26 @@
 
 namespace br
 {
+/*!
+ * \ingroup outputs
+ * \brief Adaptor class -- write a matrix output using Format classes.
+ * \author Charles Otto \cite caotto
+ */
+class DefaultOutput : public MatrixOutput
+{
+    Q_OBJECT
+
+    ~DefaultOutput()
+    {
+        if (file.isNull() || targetFiles.isEmpty() || queryFiles.isEmpty()) return;
+
+        br::Template T(this->file, this->data);
+        QScopedPointer<Format> writer(Factory<Format>::make(this->file));
+        writer->write(T);
+    }
+};
+
+BR_REGISTER(Output, DefaultOutput)
 
 /*!
  * \ingroup outputs


### PR DESCRIPTION
Add the ability to write matrix output using format classes
This allows e.g. writing .mat files as directly as output of compare, as well
as writing similarity matrices as images (although this could use some scaling)
