### PR TITLE
Online distance metric added

### DIFF
--- a/openbr/plugins/distance.cpp
+++ b/openbr/plugins/distance.cpp
@@ -320,8 +320,7 @@ class OnlineDistance : public Distance
         float currentScore = distance->compare(target, query);
 
         QMutexLocker mutexLocker(&mutex);
-        if (!scoreHash.contains(target.file.name))      scoreHash[target.file.name] = 0.0f; 
-        return (1.0- alpha) * scoreHash[target.file.name] + alpha * currentScore;
+        return scoreHash[target.file.name] = (1.0- alpha) * scoreHash[target.file.name] + alpha * currentScore;
     }
 };
 


### PR DESCRIPTION
Used to attenuate match scores across a continuous stream of image frames. This is a short term solution. A long term solution will be implementing this using this approach in a TimeVaryingTransform wrapped in a Stream.
