### PR TITLE
allow plugin to be manually specified

### DIFF
--- a/openbr/openbr_plugin.h
+++ b/openbr/openbr_plugin.h
@@ -814,7 +814,8 @@ struct Factory
     //! [Factory make]
     static T *make(const File &file)
     {
-        QString name = file.suffix();
+        QString name = file.get<QString>("plugin", "");
+        if (name.isEmpty()) name = file.suffix();
         if (!names().contains(name)) {
             if      (names().contains("Empty") && name.isEmpty()) name = "Empty";
             else if (names().contains("Default"))                 name = "Default";


### PR DESCRIPTION
@caotto @sklum Are you guys ok with the following generalization? It allows the ability to override the file extension when determining which plugin to use. @bklare and I would find this convenient in circumstances where the only other option would be changing the file extension. In our case `.txt` files could conceivably be one of many different formats, and we'd like the ability to explicitly specify which plugin to use in this ambiguous case.
