### PR TITLE
allow File::name to be queried using 'name' property

### DIFF
--- a/openbr/openbr_plugin.cpp
+++ b/openbr/openbr_plugin.cpp
@@ -127,12 +127,12 @@ QString File::resolved() const
 
 bool File::contains(const QString &key) const
 {
-    return m_metadata.contains(key) || Globals->contains(key);
+    return m_metadata.contains(key) || Globals->contains(key) || key == "name";
 }
 
 QVariant File::value(const QString &key) const
 {
-    return m_metadata.contains(key) ? m_metadata.value(key) : Globals->property(qPrintable(key));
+    return m_metadata.contains(key) ? m_metadata.value(key) : (key == "name" ? name : Globals->property(qPrintable(key)));
 }
 
 QVariant File::parse(const QString &value)

--- a/openbr/openbr_plugin.h
+++ b/openbr/openbr_plugin.h
@@ -138,6 +138,7 @@ void reset_##NAME() { NAME = DEFAULT; }
  *
  * Key             | Value          | Description
  * ---             | ----           | -----------
+ * name            | QString        | Contents of #name
  * separator       | QString        | Seperate #name into multiple files
  * Index           | int            | Index of a template in a template list
  * Confidence      | float          | Classification/Regression quality


### PR DESCRIPTION
This would allow the following ways to query `br::File::name`:

```
br::File myFile = ...;
QString myFileName = myFile.get<QString>("name"); // Equivalent to myFile.name;
```

and

```
br::TemplateList myTemplates = ...;
QStringList myFileNames = br::File::get<QString>(myTemplates, "name"); // No current equivalent
```
