### PR TITLE
Plot enhancements

### DIFF
--- a/openbr/core/plot.cpp
+++ b/openbr/core/plot.cpp
@@ -229,8 +229,6 @@ bool Plot(const QStringList &files, const File &destination, bool show)
         cmcOpts.set(words[0],words[1]);
     }
 
-    qDebug() << cmcOpts.flat();
-
     RPlot p(files, destination);
 
     p.file.write(qPrintable(QString("qplot(X, 1-Y, data=DET%1").arg((p.major.smooth || p.minor.smooth) ? ", geom=\"smooth\", method=loess, level=0.99" : ", geom=\"line\"") +


### PR DESCRIPTION
I've added the functionality to specify the following options for our CMC plots:
- Title
- Y axis limits
- Line thickness
- Legend position
- Text size

An example:
`br -plot Algorithm_medsdataset/* pdf/MEDS.pdf[minimalist, cmcOptions="[title=Retrieval Rates of OpenBR on MEDS,legendPosition=(.5,.15),yLimits=(0,.8),thickness=3,textSize=16]"]`

I'd also like to provide options for ROC plots as well, and am happy to add any that people request (or more for CMC plots).
