### PR TITLE
Loadstore updates

### DIFF
--- a/openbr/plugins/meta.cpp
+++ b/openbr/plugins/meta.cpp
@@ -499,7 +499,6 @@ private:
 
     void train(const TemplateList &data)
     {
-        // Store which partition we're in, load will take care of it before init?
         if (QFileInfo(getFileName()).exists())
             return;
 


### PR DESCRIPTION
I started out making this fancy so that we could do LoadStores as a child of CrossValidate (and thus we would need to store a model file with a name containing the partitions the training data consisted of) but then realized the CrossValidate itself must be trained, so we would need to use a model file anyway.  This basically made putting LoadStores inside CrossValidate useless, obviously, so now we have an amazing pull request adding one property to LoadStore for a user specified name.  I kept the original hash to maintain binary compatibility.

Solves #121.
