### PR TITLE
Detector template list

### DIFF
--- a/openbr/plugins/slidingwindow.cpp
+++ b/openbr/plugins/slidingwindow.cpp
@@ -107,7 +107,6 @@ private:
             return;
         }
 
-        dst.file.clearRects();
         Template windowTemplate(src.file, src);
         QList<float> confidences = dst.file.getList<float>("Confidences", QList<float>());
         for (float y = 0; y + windowHeight < src.m().rows; y += windowHeight*stepFraction) {
@@ -273,13 +272,15 @@ private:
         int rows = src.m().rows;
         int cols = src.m().cols;
         int windowHeight = (int) qRound((float) windowWidth / aspectRatio);
+
         float startScale;
         if ((cols / rows) > aspectRatio)
             startScale = qRound((float) rows / (float) windowHeight);
         else
             startScale = qRound((float) cols / (float) windowWidth);
+
         for (float scale = startScale; scale >= minScale; scale -= (1.0 - scaleFactor)) {
-            Template scaleImg(src.file, Mat());
+            Template scaleImg(dst.file, Mat());
             scaleImg.file.set("scale", scale);
             resize(src, scaleImg, Size(qRound(cols / scale), qRound(rows / scale)));
             transform->project(scaleImg, dst);


### PR DESCRIPTION
@jklontz @imaus10 This reverses the creation of new templates within the SlidingWindow loop. All other subsequent changes to the detection framework have been maintained. The accuracy of our detector has been verified to be the same prior to this merge 

Note that if you want a new Template per file, you should call the `RectsToTemplates` transform. Also note that this should get a good review, b/c I have not runtime checked it as I don't have any algorithms that need to make use this functionality. One item that I may have done incorrectly is project() with Template instead of TemplateList. 
