### PR TITLE
Split downloading the MEDS dataset to a separate file

### DIFF
--- a/scripts/downloadDatasets.sh
+++ b/scripts/downloadDatasets.sh
@@ -117,20 +117,7 @@ if [ ! -d ../data/LFW/img ]; then
   rm lfw.tgz
 fi
 
-# MEDS
-if [ ! -d ../data/MEDS/img ]; then
-  echo "Downloading MEDS..."
-  if hash curl 2>/dev/null; then
-    curl -OL http://nigos.nist.gov:8080/nist/sd/32/NIST_SD32_MEDS-II_face.zip
-  else
-    wget http://nigos.nist.gov:8080/nist/sd/32/NIST_SD32_MEDS-II_face.zip
-  fi
-
-  unzip NIST_SD32_MEDS-II_face.zip
-  mkdir ../data/MEDS/img
-  mv data/*/*.jpg ../data/MEDS/img
-  rm -r data NIST_SD32_MEDS-II_face.zip
-fi
+./downloadMeds.sh
 
 #LFPW
 if [ ! -d ../data/lfpw/trainset ]; then

--- a/scripts/downloadMEDS.sh
+++ b/scripts/downloadMEDS.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+
+# MEDS
+if [ ! -d ../data/MEDS/img ]; then
+  echo "Downloading MEDS..."
+  if hash curl 2>/dev/null; then
+    curl -OL http://nigos.nist.gov:8080/nist/sd/32/NIST_SD32_MEDS-II_face.zip
+  else
+    wget http://nigos.nist.gov:8080/nist/sd/32/NIST_SD32_MEDS-II_face.zip
+  fi
+
+  unzip NIST_SD32_MEDS-II_face.zip
+  mkdir ../data/MEDS/img
+  mv data/*/*.jpg ../data/MEDS/img
+  rm -r data NIST_SD32_MEDS-II_face.zip
+fi

--- a/scripts/evalFaceRecognition-MEDS.sh
+++ b/scripts/evalFaceRecognition-MEDS.sh
@@ -13,7 +13,7 @@ if ! hash br 2>/dev/null; then
 fi
 
 # Get the data
-./downloadDatasets.sh
+./downloadMEDS.sh
 
 if [ ! -e Algorithm_Dataset ]; then
   mkdir Algorithm_Dataset


### PR DESCRIPTION
downloading all the datasets in downloadDatasets.sh is time consuming, and
MEDS is the only dataset used in make test, as well as
evalFaceRecognition-MEDS.sh. Splitting MEDS to a searate file simplifies
the process of validating an OpenBR build.
