### PR TITLE
Introduce transforms which operate solely on metadata

### DIFF
--- a/openbr/plugins/landmarks.cpp
+++ b/openbr/plugins/landmarks.cpp
@@ -370,7 +370,7 @@ BR_REGISTER(Transform, ReadLandmarksTransform)
  * \brief Name a point
  * \author Scott Klum \cite sklum
  */
-class NamePointsTransform : public UntrainableMetaTransform
+class NamePointsTransform : public UntrainableMetadataTransform
 {
     Q_OBJECT
     Q_PROPERTY(QList<int> indices READ get_indices WRITE set_indices RESET reset_indices STORED false)
@@ -378,16 +378,16 @@ class NamePointsTransform : public UntrainableMetaTransform
     BR_PROPERTY(QList<int>, indices, QList<int>())
     BR_PROPERTY(QStringList, names, QStringList())
 
-    void project(const Template &src, Template &dst) const
+    void project(const File &src, File &dst) const
     {
         if (indices.size() != names.size()) qFatal("Point/name size mismatch");
 
         dst = src;
 
-        QList<QPointF> points = src.file.points();
+        QList<QPointF> points = src.points();
 
         for (int i=0; i<indices.size(); i++) {
-            if (indices[i] < points.size()) dst.file.set(names[i], points[indices[i]]);
+            if (indices[i] < points.size()) dst.set(names[i], points[indices[i]]);
             else qFatal("Index out of range.");
         }
     }
@@ -400,18 +400,18 @@ BR_REGISTER(Transform, NamePointsTransform)
  * \brief Remove a name from a point
  * \author Scott Klum \cite sklum
  */
-class AnonymizePointsTransform : public UntrainableMetaTransform
+class AnonymizePointsTransform : public UntrainableMetadataTransform
 {
     Q_OBJECT
     Q_PROPERTY(QStringList names READ get_names WRITE set_names RESET reset_names STORED false)
     BR_PROPERTY(QStringList, names, QStringList())
 
-    void project(const Template &src, Template &dst) const
+    void project(const File &src, File &dst) const
     {
         dst = src;
 
         foreach (const QString &name, names)
-            if (src.file.contains(name)) dst.file.appendPoint(src.file.get<QPointF>(name));
+            if (src.contains(name)) dst.appendPoint(src.get<QPointF>(name));
     }
 };
 

--- a/openbr/plugins/misc.cpp
+++ b/openbr/plugins/misc.cpp
@@ -239,7 +239,7 @@ BR_REGISTER(Transform, RemoveTransform)
  * \brief Rename metadata key
  * \author Josh Klontz \cite jklontz
  */
-class RenameTransform : public UntrainableMetaTransform
+class RenameTransform : public UntrainableMetadataTransform
 {
     Q_OBJECT
     Q_PROPERTY(QString find READ get_find WRITE set_find RESET reset_find STORED false)
@@ -247,12 +247,12 @@ class RenameTransform : public UntrainableMetaTransform
     BR_PROPERTY(QString, find, "")
     BR_PROPERTY(QString, replace, "")
 
-    void project(const Template &src, Template &dst) const
+    void project(const File &src, File &dst) const
     {
         dst = src;
-        if (dst.file.localKeys().contains(find)) {
-            dst.file.set(replace, dst.file.value(find));
-            dst.file.remove(find);
+        if (dst.localKeys().contains(find)) {
+            dst.set(replace, dst.value(find));
+            dst.remove(find);
         }
     }
 };
@@ -264,7 +264,7 @@ BR_REGISTER(Transform, RenameTransform)
  * \brief Rename first found metadata key
  * \author Josh Klontz \cite jklontz
  */
-class RenameFirstTransform : public UntrainableMetaTransform
+class RenameFirstTransform : public UntrainableMetadataTransform
 {
     Q_OBJECT
     Q_PROPERTY(QStringList find READ get_find WRITE set_find RESET reset_find STORED false)
@@ -272,13 +272,13 @@ class RenameFirstTransform : public UntrainableMetaTransform
     BR_PROPERTY(QStringList, find, QStringList())
     BR_PROPERTY(QString, replace, "")
 
-    void project(const Template &src, Template &dst) const
+    void project(const File &src, File &dst) const
     {
         dst = src;
         foreach (const QString &key, find)
-            if (dst.file.localKeys().contains(key)) {
-                dst.file.set(replace, dst.file.value(key));
-                dst.file.remove(key);
+            if (dst.localKeys().contains(key)) {
+                dst.set(replace, dst.value(key));
+                dst.remove(key);
                 break;
             }
     }
@@ -291,16 +291,16 @@ BR_REGISTER(Transform, RenameFirstTransform)
  * \brief Change the br::Template::file extension
  * \author Josh Klontz \cite jklontz
  */
-class AsTransform : public UntrainableMetaTransform
+class AsTransform : public UntrainableMetadataTransform
 {
     Q_OBJECT
     Q_PROPERTY(QString extension READ get_extension WRITE set_extension RESET reset_extension STORED false)
     BR_PROPERTY(QString, extension, "")
 
-    void project(const Template &src, Template &dst) const
+    void project(const File &src, File &dst) const
     {
         dst = src;
-        dst.file.name = dst.file.name.left(dst.file.name.lastIndexOf('.')+1) + extension;
+        dst.name = dst.name.left(dst.name.lastIndexOf('.')+1) + extension;
     }
 };
 
@@ -311,7 +311,7 @@ BR_REGISTER(Transform, AsTransform)
  * \brief Apply the input regular expression to the value of inputProperty, store the matched portion in outputProperty.
  * \author Charles Otto \cite caotto
  */
-class RegexPropertyTransform : public UntrainableMetaTransform
+class RegexPropertyTransform : public UntrainableMetadataTransform
 {
     Q_OBJECT
     Q_PROPERTY(QString regexp READ get_regexp WRITE set_regexp RESET reset_regexp STORED false)
@@ -321,14 +321,14 @@ class RegexPropertyTransform : public UntrainableMetaTransform
     BR_PROPERTY(QString, inputProperty, "name")
     BR_PROPERTY(QString, outputProperty, "Label")
 
-    void project(const Template &src, Template &dst) const
+    void project(const File &src, File &dst) const
     {
         dst = src;
         QRegularExpression re(regexp);
-        QRegularExpressionMatch match = re.match(dst.file.get<QString>(inputProperty));
+        QRegularExpressionMatch match = re.match(dst.get<QString>(inputProperty));
         if (!match.hasMatch())
-            qFatal("Unable to match regular expression \"%s\" to base name \"%s\"!", qPrintable(regexp), qPrintable(dst.file.get<QString>(inputProperty)));
-        dst.file.set(outputProperty, match.captured(match.lastCapturedIndex()));
+            qFatal("Unable to match regular expression \"%s\" to base name \"%s\"!", qPrintable(regexp), qPrintable(dst.get<QString>(inputProperty)));
+        dst.set(outputProperty, match.captured(match.lastCapturedIndex()));
     }
 };
 

--- a/openbr/plugins/openbr_internal.h
+++ b/openbr/plugins/openbr_internal.h
@@ -314,6 +314,37 @@ struct WorkerProcess
     void mainLoop();
 };
 
+/*!
+ * \brief A br::Transform that operates solely on metadata
+ */
+class MetadataTransform : public Transform
+{
+    Q_OBJECT
+public:
+
+    virtual void project(const File &src, File &dst) const = 0;
+
+    void project(const Template & src, Template & dst) const
+    {
+        dst = src;
+        project(src.file, dst.file);
+    }
+
+protected:
+    MetadataTransform(bool trainable = true) : Transform(false,trainable) {}
+};
+
+/*!
+ * \brief A br::Transform that operates solely on metadata, and is untrainable
+ */
+class UntrainableMetadataTransform : public MetadataTransform
+{
+    Q_OBJECT
+
+protected:
+    UntrainableMetadataTransform() : MetadataTransform(false) {}
+};
+
 }
 
 #endif // OPENBR_INTERNAL_H

--- a/openbr/plugins/template.cpp
+++ b/openbr/plugins/template.cpp
@@ -9,17 +9,17 @@ namespace br
  * \brief Retains only the values for the keys listed, to reduce template size
  * \author Scott Klum \cite sklum
  */
-class KeepMetadataTransform : public UntrainableTransform
+class KeepMetadataTransform : public UntrainableMetadataTransform
 {
     Q_OBJECT
     Q_PROPERTY(QStringList keys READ get_keys WRITE set_keys RESET reset_keys STORED false)
     BR_PROPERTY(QStringList, keys, QStringList())
 
-    void project(const Template &src, Template &dst) const
+    void project(const File &src, File &dst) const
     {
         dst = src;
-        foreach(const QString& localKey, dst.file.localKeys()) {
-            if (!keys.contains(localKey)) dst.file.remove(localKey);
+        foreach(const QString& localKey, dst.localKeys()) {
+            if (!keys.contains(localKey)) dst.remove(localKey);
         }
     }
 };
@@ -55,17 +55,17 @@ BR_REGISTER(Transform, RemoveTemplatesTransform)
  * \brief Removes a metadata field from all templates
  * \author Brendan Klare \cite bklare
  */
-class RemoveMetadataTransform : public UntrainableTransform
+class RemoveMetadataTransform : public UntrainableMetadataTransform
 {
     Q_OBJECT
     Q_PROPERTY(QString attributeName READ get_attributeName WRITE set_attributeName RESET reset_attributeName STORED false)
     BR_PROPERTY(QString, attributeName, "None")
 
-    void project(const Template &src, Template &dst) const
+    void project(const File &src, File &dst) const
     {
         dst = src;
-        if (dst.file.contains(attributeName))
-            dst.file.remove(attributeName);
+        if (dst.contains(attributeName))
+            dst.remove(attributeName);
     }
 };
 BR_REGISTER(Transform, RemoveMetadataTransform)
@@ -75,19 +75,19 @@ BR_REGISTER(Transform, RemoveMetadataTransform)
  * \brief Retains only landmarks/points at the provided indices
  * \author Brendan Klare \cite bklare
  */
-class SelectPointsTransform : public UntrainableTransform
+class SelectPointsTransform : public UntrainableMetadataTransform
 {
     Q_OBJECT
     Q_PROPERTY(QList<int> indices READ get_indices WRITE set_indices RESET reset_indices STORED false)
     BR_PROPERTY(QList<int>, indices, QList<int>())
 
-    void project(const Template &src, Template &dst) const
+    void project(const File &src, File &dst) const
     {
         dst = src;
-        QList<QPointF> origPoints = src.file.points();
-        dst.file.clearPoints();
+        QList<QPointF> origPoints = src.points();
+        dst.clearPoints();
         for (int i = 0; i < indices.size(); i++)
-            dst.file.appendPoint(origPoints[indices[i]]);
+            dst.appendPoint(origPoints[indices[i]]);
     }
 };
 


### PR DESCRIPTION
Per #176, this commit adds an interface for transforms that only affect metadata, and makes all the metadata only transform I noticed inherit from it.
