### PR TITLE
only run the event loop in gui mode

### DIFF
--- a/app/br/br.cpp
+++ b/app/br/br.cpp
@@ -271,11 +271,16 @@ private:
 
 int main(int argc, char *argv[])
 {
-    br_initialize(argc, argv, "", argc >= 2 && !strcmp(argv[1], "-gui"));
+    const bool gui         = (argc >= 2) && !strcmp(argv[1], "-gui");
+    const bool noEventLoop = (argc >= 2) && !strcmp(argv[1], "-noEventLoop");
+    br_initialize(argc, argv, "", gui);
 
-    FakeMain *fakeMain = new FakeMain(argc, argv);
-    QThreadPool::globalInstance()->start(fakeMain);
-    QCoreApplication::exec();
+    if (noEventLoop) {
+        FakeMain(argc, argv).run();
+    } else {
+        QThreadPool::globalInstance()->start(new FakeMain(argc, argv));
+        QCoreApplication::exec();
+    }
 
     br_finalize();
 }


### PR DESCRIPTION
@caotto Getting stack traces in OpenBR has been tricky lately due to the threading indirection in:
1. The FakeMain argument parsing
2. Multi-threaded enrollment

This is the first of two pull requests designed to make stack traces easier to acquire. Here we make `-gui` synonymous to running an event loop.
