### PR TITLE
Have Cascade propagate empty templates when enrollAll is false, for #207

### DIFF
--- a/openbr/plugins/cascade.cpp
+++ b/openbr/plugins/cascade.cpp
@@ -379,6 +379,13 @@ class CascadeTransform : public MetaTransform
         foreach (const Template &t, src) {
             const bool enrollAll = t.file.getBool("enrollAll");
 
+            // Mirror the behavior of ExpandTransform in the special case
+            // of an empty template.
+            if (t.empty() && !enrollAll) {
+                dst.append(t);
+                continue;
+            }
+
             for (int i=0; i<t.size(); i++) {
                 const Mat &m = t[i];
                 std::vector<Rect> rects;


### PR DESCRIPTION
@caotto Do you see any reason why this is a bad idea? For my use case, I need Gallery writes to be triggered for empty templates (caused by Open failure). This seems to be consistent with ExpandTransform's behavior.
