### PR TITLE
Refactor PP5 comparison handling

### DIFF
--- a/openbr/openbr_plugin.cpp
+++ b/openbr/openbr_plugin.cpp
@@ -875,7 +875,7 @@ void br::Context::printStatus()
     const float p = progress();
     if (p < 1) {
         int s = timeRemaining();
-        fprintf(stderr,"%05.2f%%  ELAPSED=%s  REMAINING=%s  COUNT=%g  \r", p*100, QtUtils::toTime(Globals->startTime.elapsed()/1000.0f).toStdString().c_str(), QtUtils::toTime(s).toStdString().c_str(), Globals->currentStep);
+        fprintf(stderr,"\r%05.2f%%  ELAPSED=%s  REMAINING=%s  COUNT=%g", p*100, QtUtils::toTime(Globals->startTime.elapsed()/1000.0f).toStdString().c_str(), QtUtils::toTime(s).toStdString().c_str(), Globals->currentStep);
         fflush(stderr);
     }
 }

--- a/openbr/plugins/gallery.cpp
+++ b/openbr/plugins/gallery.cpp
@@ -129,7 +129,7 @@ class BinaryGallery : public Gallery
             if (t.isEmpty() && t.file.isNull())
                 continue;
             templates.append(t);
-            templates.last().file.set("progress", totalSize());
+            templates.last().file.set("progress", position());
 
             // Special case for pipes where we want to process data as soon as it is available
             if (gallery.isSequential())


### PR DESCRIPTION
Introduce PP5GalleryTransform, a transform that compares incoming templates
against a fixed gallery (thereby avoiding the cost of repeatedly setting up
pp5 galleries for the same templates).

Modify AlgorithmCore to support supplying Transforms to the right of the
: in an algorithm string. If a distance cannot be created (testing if
defaultDistance is returned from Distance::make), store the comparison
part as a string, and use it to make a replacement for GalleryCompareTransfrom
in calls to AlgorithmCore::compare

This commit essentially disables DefaultDistance (which could previously
be used as a shorthand for DistDistance with some specific metric),
instead leaving DefaultDistance as a non-functional distance.
