### PR TITLE
A stopwatch and profiler to get time data for specified openbr transforms

### DIFF
--- a/openbr/plugins/time.cpp
+++ b/openbr/plugins/time.cpp
@@ -15,9 +15,9 @@ class StopWatchTransform : public TimeVaryingTransform
     Q_PROPERTY(br::Transform* child READ get_child WRITE set_child RESET reset_child)
     BR_PROPERTY(br::Transform*, child, NULL)
 
-    mutable long timeElapsed;
-    mutable long numImgs;
-    mutable long numPixels;
+    long timeElapsed;
+    long numImgs;
+    long numPixels;
 
 public:
     StopWatchTransform() : TimeVaryingTransform(false, false)


### PR DESCRIPTION
A really basic stopwatch that can wrap any OpenBR transform or aggregated transform such as StopWatch(Cascade(FrontalFace)) or StopWatch(Cvt(Gray)+Cascade(FrontalFace)). Data is stored in file metadata using the "time" key. An optional profiler can be appended to the end of an algorithm to display the time data "Algorithm (with stopwatch) + StopWatchProfiler". 
