### PR TITLE
New algorithm ID, same stuff as the old ID

### DIFF
--- a/openbr/plugins/gallery.cpp
+++ b/openbr/plugins/gallery.cpp
@@ -251,7 +251,7 @@ class utGallery : public BinaryGallery
             t.file.set("URL", QString(data.data()));
             char *dataStart = data.data() + ut.urlSize;
             uint32_t dataSize = ut.size - ut.urlSize;
-            if (ut.algorithmID == -1) {
+            if (ut.algorithmID == -1 || ut.algorithmID == -2) {
                 t.file.set("FrontalFace", QRectF(ut.x, ut.y, ut.width, ut.height));
                 uint32_t *rightEyeX = reinterpret_cast<uint32_t*>(dataStart);
                 dataStart += sizeof(uint32_t);


### PR DESCRIPTION
smallest pull request ever.

@bklare This will require retraining of the Component algorithm to set -2 instead of -1. This is necessary because -1 is expected to have a 768 byte feature vector.

In addition to the eye locations that are saved in `data` (see the content of the if), do we want to save any other landmarks in the future for this algorithm?

I think it's a good idea to have a range of IDs that all have the same behavior. For example, all IDs >= -10 and <= -1 are FR algs and all save certain landmark locations in the first n bytes. @jklontz weigh in too!
