### PR TITLE
Introduce -assertEval.  

### DIFF
--- a/app/br/br.cpp
+++ b/app/br/br.cpp
@@ -150,6 +150,9 @@ public:
             } else if (!strcmp(fun, "convert")) {
                 check(parc == 3, "Incorrect parameter count for 'convert'.");
                 br_convert(parv[0], parv[1], parv[2]);
+            } else if (!strcmp(fun, "assertEval")) {
+                check(parc == 3, "Incorrect parameter count for 'assertEval'.");
+                br_assert_eval(parv[0], parv[1], atof(parv[2]));
             } else if (!strcmp(fun, "evalClassification")) {
                 check(parc >= 2 && parc <= 4, "Incorrect parameter count for 'evalClassification'.");
                 br_eval_classification(parv[0], parv[1], parc >= 3 ? parv[2] : "", parc >= 4 ? parv[3] : "");
@@ -263,6 +266,7 @@ private:
                "-evalDetection <predicted_gallery> <truth_gallery> [{csv}] [{normalize}] [{minSize}]\n"
                "-evalLandmarking <predicted_gallery> <truth_gallery> [{csv} [<normalization_index_a> <normalization_index_b>]]\n"
                "-evalRegression <predicted_gallery> <truth_gallery> <predicted property name> <ground truth property name>\n"
+               "-assertEval <simmat> <mask> <accuracy>\n"
                "-plotDetection <file> ... <file> {destination}\n"
                "-plotLandmarking <file> ... <file> {destination}\n"
                "-plotMetadata <file> ... <file> <columns>\n"

--- a/openbr/core/eval.cpp
+++ b/openbr/core/eval.cpp
@@ -347,6 +347,17 @@ float Evaluate(const Mat &simmat, const Mat &mask, const QString &csv, const QSt
     return result;
 }
 
+void assertEval(const QString &simmat, const QString &mask, float accuracy)
+{
+    float result = Evaluate(simmat, mask, "", 0);
+    // Round result to nearest thousandth for comparison against input accuracy.  Input is expected to be from previous
+    // results of br -eval.
+    result = floor(result*1000+0.5)/1000;
+    if (result < accuracy) {
+        qFatal("TAR @ FAR = 0.01 does not meet required accuracy: %.3f < %.3f", result, accuracy);
+    }
+}
+
 struct GenImpCounts
 {
     GenImpCounts()

--- a/openbr/core/eval.h
+++ b/openbr/core/eval.h
@@ -26,6 +26,7 @@ namespace br
     float Evaluate(const QString &simmat, const QString &mask = "", const QString &csv = "", unsigned int matches = 0); // Returns TAR @ FAR = 0.001
     float Evaluate(const cv::Mat &scores, const FileList &target, const FileList &query, const QString &csv = "", int parition = 0);
     float Evaluate(const cv::Mat &scores, const cv::Mat &masks, const QString &csv = "", const QString &target = "", const QString &query = "", unsigned int matches = 0);
+    void assertEval(const QString &simmat, const QString &mask, float accuracy); // Check to see if -eval achieves a given TAR @ FAR = 0.001
     float InplaceEval(const QString & simmat, const QString & target, const QString & query, const QString & csv = "");
 
     void EvalClassification(const QString &predictedGallery, const QString &truthGallery, QString predictedProperty = "", QString truthProperty = "");

--- a/openbr/openbr.cpp
+++ b/openbr/openbr.cpp
@@ -109,6 +109,11 @@ float br_eval(const char *simmat, const char *mask, const char *csv, int matches
     return Evaluate(simmat, mask, csv, matches);
 }
 
+void br_assert_eval(const char *simmat, const char *mask, const float accuracy)
+{
+    assertEval(simmat, mask, accuracy);
+}
+
 float br_inplace_eval(const char *simmat, const char *target, const char *query, const char *csv)
 {
     return InplaceEval(simmat, target, query, csv);

--- a/openbr/openbr.h
+++ b/openbr/openbr.h
@@ -161,6 +161,14 @@ BR_EXPORT void br_project(const char *input, const char *output);
 BR_EXPORT float br_eval(const char *simmat, const char *mask, const char *csv = "", int matches = 0);
 
 /*!
+ * \brief Evaluates the similarity matrix using the mask matrix.  Function aborts ff TAR @ FAR = 0.001 does not meet an expected performance value
+ * \param simmat The \ref simmat to use.
+ * \param mask The \ref mask to use.
+ * \param accuracy Desired true accept rate at false accept rate of one in one thousand.
+ */
+ BR_EXPORT void br_assert_eval(const char *simmat, const char *mask, const float accuracy);
+
+/*!
  * \brief Creates a \c .csv file containing performance metrics from evaluating the similarity matrix using galleries containing ground truth labels
  * \param simmat The \ref simmat to use.
  * \param target the name of a gallery containing metadata for the target set.


### PR DESCRIPTION
Takes simmat, mask and TAR@FAR = 0.001 accuracy metric, errors out if result of Evaluate() does not meet or exceed metric.
