### PR TITLE
don't save matrix data for failure to enroll templates

### DIFF
--- a/openbr/plugins/gallery.cpp
+++ b/openbr/plugins/gallery.cpp
@@ -209,7 +209,10 @@ class galGallery : public BinaryGallery
     {
         if (t.isEmpty() && t.file.isNull())
             return;
-        stream << t;
+        else if (t.file.fte)
+            stream << Template(t.file); // only write metadata for failure to enroll
+        else
+            stream << t;
     }
 };
 


### PR DESCRIPTION
Now that FTE short circuits the algorithm, we end up saving decoded images in the `.gal` file in the event of an FTE. This patch fixes that issue.
