### PR TITLE
Ut refactor

### DIFF
--- a/openbr/plugins/gallery.cpp
+++ b/openbr/plugins/gallery.cpp
@@ -313,15 +313,15 @@ class utGallery : public BinaryGallery
             width = t.file.get<uint32_t>("Width", 0);
             height = t.file.get<uint32_t>("Height", 0);
         }
-        const double label = t.file.get<double>("Label", 0);
+        const uint32_t label = t.file.get<uint32_t>("Label", 0);
 
         gallery.write(imageID);
-        gallery.write((const char*) &algorithmID, sizeof(uint32_t));
+        gallery.write((const char*) &algorithmID, sizeof(int32_t));
         gallery.write((const char*) &x          , sizeof(uint32_t));
         gallery.write((const char*) &y          , sizeof(uint32_t));
         gallery.write((const char*) &width      , sizeof(uint32_t));
         gallery.write((const char*) &height     , sizeof(uint32_t));
-        gallery.write((const char*) &label      , sizeof(double));
+        gallery.write((const char*) &label      , sizeof(uint32_t));
 
         const uint32_t urlSize = url.size() + 1;
         gallery.write((const char*) &urlSize, sizeof(uint32_t));

--- a/openbr/universal_template.cpp
+++ b/openbr/universal_template.cpp
@@ -8,7 +8,7 @@
 
 #include "universal_template.h"
 
-br_utemplate br_new_utemplate(const int8_t *imageID, int32_t algorithmID, size_t x, size_t y, size_t width, size_t height, double label, const char *url, const char *fv, uint32_t fvSize)
+br_utemplate br_new_utemplate(const char *imageID, int32_t algorithmID, uint32_t x, uint32_t y, uint32_t width, uint32_t height, uint32_t label, const char *url, const char *fv, uint32_t fvSize)
 {
     const uint32_t urlSize = strlen(url) + 1;
     br_utemplate utemplate = (br_utemplate) malloc(sizeof(br_universal_template) + urlSize + fvSize);

--- a/openbr/universal_template.h
+++ b/openbr/universal_template.h
@@ -41,8 +41,7 @@ struct br_universal_template
     uint32_t y;      /*!< region of interest vertical offset (pixels). */
     uint32_t width;  /*!< region of interest horizontal size (pixels). */
     uint32_t height; /*!< region of interest vertical size (pixels). */
-    double label; /*!< classification/regression supervised training class,
-                       or manually annotated ground truth. */
+    uint32_t label; /*!< supervised training class or manually annotated ground truth. */
     uint32_t urlSize; /*!< length of null-terminated URL at the beginning of _data_,
                            including the null-terminator character. */
     uint32_t fvSize; /*!< length of the feature vector after the URL in _data_. */
@@ -58,7 +57,7 @@ typedef const struct br_universal_template *br_const_utemplate;
  * \brief br_universal_template constructor.
  * \see br_free_utemplate
  */
-BR_EXPORT br_utemplate br_new_utemplate(const int8_t *imageID, int32_t algorithmID, size_t x, size_t y, size_t width, size_t height, double label, const char *url, const char *fv, uint32_t fvSize);
+BR_EXPORT br_utemplate br_new_utemplate(const char *imageID, int32_t algorithmID, uint32_t x, uint32_t y, uint32_t width, uint32_t height, uint32_t label, const char *url, const char *fv, uint32_t fvSize);
 
 /*!
  * \brief br_universal_template destructor.


### PR DESCRIPTION
@bklare @imaus10 The PR implements the following changes I propose for the `br_universal_template` format:
1. Removal of the `unsigned char templateID[16]` field. The TemplateID is redundant information, as the template can be uniquely identified given either a) the feature vector itself, or b) the combination of ImageID, AlgorithmID, X, Y, Width, and Height (aka the template “metadata”).
2. Addition of a `uint32_t label` field. The purpose of this field is to associate ground truth information with the template. Use cases include a) manually annotated ground truth in an operational environment, and b) training statistical learning algorithms outside of OpenBR (in Matlab, Likely, etc.), where the  `br_universal_template` provides a convenient cross-framework feature vector representation. I had originally intended to make this a `double` but ran into trouble with struct packing, technical details available if interested.
3. Change the syntax and semantics of `br_universal_template::size` to `br_universal_template::fvSize`. This is to make it a little easier to iterate over the feature vector, as the feature vector size is now explicitly available. The tradeoff is that the total size of br_universal_template::data must be calculated by adding `urlSize + fvSize`.
