### PR TITLE
Added ReadTransform

### DIFF
--- a/openbr/plugins/misc.cpp
+++ b/openbr/plugins/misc.cpp
@@ -90,6 +90,48 @@ BR_REGISTER(Transform, DecodeTransform)
 
 /*!
  * \ingroup transforms
+ * \brief Read images
+ * \author Josh Klontz \cite jklontz
+ */
+class ReadTransform : public UntrainableMetaTransform
+{
+    Q_OBJECT
+    Q_ENUMS(Mode)
+    Q_PROPERTY(Mode mode READ get_mode WRITE set_mode RESET reset_mode)
+
+public:
+    enum Mode
+    {
+        Unchanged = IMREAD_UNCHANGED,
+        Grayscale = IMREAD_GRAYSCALE,
+        Color     = IMREAD_COLOR,
+        AnyDepth  = IMREAD_ANYDEPTH,
+        AnyColor  = IMREAD_ANYCOLOR
+    };
+
+private:
+    BR_PROPERTY(Mode, mode, Color)
+
+    void project(const Template &src, Template &dst) const
+    {
+        dst.file = src.file;
+        if (src.empty()) {
+            const Mat img = imread(src.file.resolved().toStdString(), mode);
+            if (img.data) dst.append(img);
+            else          dst.file.fte = true;
+        } else {
+            foreach (const Mat &m, src) {
+                const Mat img = imdecode(m, mode);
+                if (img.data) dst.append(img);
+                else          dst.file.fte = true;
+            }
+        }
+    }
+};
+BR_REGISTER(Transform, ReadTransform)
+
+/*!
+ * \ingroup transforms
  * \brief Downloads an image from a URL
  * \author Josh Klontz \cite jklontz
  */


### PR DESCRIPTION
@sklum @bklare Profiling the Component algorithm seems to suggest we waste a lot of time in color space conversions:
1. Read an image in BGR
2. Convert entire image to Grayscale for PP5
3. Convert entire image to Grayscale for Stasm
4. Affine transform in BGR
5. Convert registered face to Grayscale

What we should do is:
1. Read an image in Grayscale
2. No conversion needed for PP5
3. No conversion needed for Stasm
4. Affine transform in Grayscale
5. No conversion needed for feature extraction

This pull request introduces a new transform to expose step 1, allowing:
`Open+DiscardAlpha+SetMetadata(AlgorithmID,-3)+LandmarksAffine+Cvt(Gray)`
to be rewritten as:
`Read(Grayscale)+SetMetadata(AlgorithmID,-3)+LandmarksAffine`
resulting in a **~40%** speed improvement!

@imaus10 Note that this obviates the need for `DiscardAlpha` entirely, as the logic for handling alpha channels is moved into `cv::imread`. WRT br_universal_template, this transform assumes incoming images from .ut files are _encoded_. Please confirm we aren't currently passing _decoded_ images. If we are, I'll have to introduce a few more changes!
