### PR TITLE
Address issues #242, #192

### DIFF
--- a/openbr/plugins/openbr_internal.h
+++ b/openbr/plugins/openbr_internal.h
@@ -464,14 +464,17 @@ class FileGallery : public Gallery
     Q_OBJECT
 public:
     QFile f;
-    qint64 fileSize;
 
     virtual ~FileGallery() { f.close(); }
 
     void init();
 
-    qint64 totalSize() { return fileSize; }
+    qint64 totalSize();
     qint64 position() { return f.pos(); }
+
+    bool readOpen();
+    void writeOpen();
+
 };
 
 


### PR DESCRIPTION
Instead of opening gallery files in init methods, defer until read/write are first called. This avoids the need to open in r/w mode, which caused a number of problems (such as #242, #192), as well as general oddness such as requiring w permissions when it shouldn't really be necessary. 
