### PR TITLE
Fix for issue #260

### DIFF
--- a/openbr/core/core.cpp
+++ b/openbr/core/core.cpp
@@ -280,6 +280,9 @@ struct AlgorithmCore
         TemplateList queries = q->read();
         TemplateList targets = t->read();
 
+        output.set("targetGallery", targetGallery.name );
+        output.set("queryGallery", queryGallery.name );
+
         // Use a single file for one of the dimensions so that the output makes the right size file
         FileList dummyTarget;
         dummyTarget.append(targets[0]);


### PR DESCRIPTION
Explicitly store query/gallery file names as metadata in the output created  in pairwiseCompare, fixes issue  #260 (evalFaceRecognition-LFW.sh not working).
