### PR TITLE
introduced br::Distance::trainable() and UntrainableDistance

### DIFF
--- a/openbr/core/core.cpp
+++ b/openbr/core/core.cpp
@@ -77,7 +77,7 @@ struct AlgorithmCore
         qDebug("Training Enrollment");
         trainingWrapper->train(data);
 
-        if (!distance.isNull()) {
+        if (!distance.isNull() && distance->trainable()) {
             if (Globals->crossValidate > 0)
                 for (int i=data.size()-1; i>=0; i--) if (data[i].file.get<bool>("allPartitions",false)) data.removeAt(i);
 

--- a/openbr/openbr_plugin.h
+++ b/openbr/openbr_plugin.h
@@ -1358,7 +1358,8 @@ public:
     static Distance *make(QString str, QObject *parent); /*!< \brief Make a distance from a string. */
 
     static QSharedPointer<Distance> fromAlgorithm(const QString &algorithm); /*!< \brief Retrieve an algorithm's distance. */
-    virtual void train(const TemplateList &src) { (void) src; } /*!< \brief Train the distance. */
+    virtual bool trainable() { return true; } /*!< \brief \c true if The distance implements train(), false otherwise. */
+    virtual void train(const TemplateList &src) = 0; /*!< \brief Train the distance. */
     virtual void compare(const TemplateList &target, const TemplateList &query, Output *output) const; /*!< \brief Compare two template lists. */
     virtual QList<float> compare(const TemplateList &targets, const Template &query) const; /*!< \brief Compute the normalized distance between a template and a template list. */
     virtual float compare(const Template &a, const Template &b) const; /*!< \brief Compute the distance between two templates. */

--- a/openbr/plugins/distance.cpp
+++ b/openbr/plugins/distance.cpp
@@ -35,7 +35,7 @@ namespace br
  * \brief Standard distance metrics
  * \author Josh Klontz \cite jklontz
  */
-class DistDistance : public Distance
+class DistDistance : public UntrainableDistance
 {
     Q_OBJECT
     Q_ENUMS(Metric)
@@ -128,7 +128,7 @@ BR_REGISTER(Distance, DistDistance)
  * \brief DistDistance wrapper.
  * \author Josh Klontz \cite jklontz
  */
-class DefaultDistance : public Distance
+class DefaultDistance : public UntrainableDistance
 {
     Q_OBJECT
     Distance *distance;
@@ -279,7 +279,7 @@ BR_REGISTER(Distance, FuseDistance)
  * \brief Fast 8-bit L1 distance
  * \author Josh Klontz \cite jklontz
  */
-class ByteL1Distance : public Distance
+class ByteL1Distance : public UntrainableDistance
 {
     Q_OBJECT
 
@@ -296,7 +296,7 @@ BR_REGISTER(Distance, ByteL1Distance)
  * \brief Fast 4-bit L1 distance
  * \author Josh Klontz \cite jklontz
  */
-class HalfByteL1Distance : public Distance
+class HalfByteL1Distance : public UntrainableDistance
 {
     Q_OBJECT
 
@@ -313,7 +313,7 @@ BR_REGISTER(Distance, HalfByteL1Distance)
  * \brief Returns -log(distance(a,b)+1)
  * \author Josh Klontz \cite jklontz
  */
-class NegativeLogPlusOneDistance : public Distance
+class NegativeLogPlusOneDistance : public UntrainableDistance
 {
     Q_OBJECT
     Q_PROPERTY(br::Distance* distance READ get_distance WRITE set_distance RESET reset_distance STORED false)
@@ -347,7 +347,7 @@ BR_REGISTER(Distance, NegativeLogPlusOneDistance)
  * \brief Returns \c true if the templates are identical, \c false otherwise.
  * \author Josh Klontz \cite jklontz
  */
-class IdenticalDistance : public Distance
+class IdenticalDistance : public UntrainableDistance
 {
     Q_OBJECT
 
@@ -368,7 +368,7 @@ BR_REGISTER(Distance, IdenticalDistance)
  * \brief Online distance metric to attenuate match scores across multiple frames
  * \author Brendan klare \cite bklare
  */
-class OnlineDistance : public Distance
+class OnlineDistance : public UntrainableDistance
 {
     Q_OBJECT
     Q_PROPERTY(br::Distance* distance READ get_distance WRITE set_distance RESET reset_distance STORED false)
@@ -395,7 +395,7 @@ BR_REGISTER(Distance, OnlineDistance)
  * \brief Attenuation function based distance from attributes
  * \author Scott Klum \cite sklum
  */
-class AttributeDistance : public Distance
+class AttributeDistance : public UntrainableDistance
 {
     Q_OBJECT
     Q_PROPERTY(QString attribute READ get_attribute WRITE set_attribute RESET reset_attribute STORED false)
@@ -421,7 +421,7 @@ BR_REGISTER(Distance, AttributeDistance)
  * \brief Sum match scores across multiple distances
  * \author Scott Klum \cite sklum
  */
-class SumDistance : public Distance
+class SumDistance : public UntrainableDistance
 {
     Q_OBJECT
     Q_PROPERTY(QList<br::Distance*> distances READ get_distances WRITE set_distances RESET reset_distances)

--- a/openbr/plugins/eigen3.cpp
+++ b/openbr/plugins/eigen3.cpp
@@ -657,7 +657,7 @@ BR_REGISTER(Transform, SparseLDATransform)
  * \brief L1 distance computed using eigen.
  * \author Josh Klontz \cite jklontz
  */
-class L1Distance : public Distance
+class L1Distance : public UntrainableDistance
 {
     Q_OBJECT
 
@@ -677,7 +677,7 @@ BR_REGISTER(Distance, L1Distance)
  * \brief L2 distance computed using eigen.
  * \author Josh Klontz \cite jklontz
  */
-class L2Distance : public Distance
+class L2Distance : public UntrainableDistance
 {
     Q_OBJECT
 

--- a/openbr/plugins/keypoint.cpp
+++ b/openbr/plugins/keypoint.cpp
@@ -109,7 +109,7 @@ BR_REGISTER(Transform, KeyPointDescriptorTransform)
  * \brief Wraps OpenCV Key Point Matcher
  * \author Josh Klontz \cite jklontz
  */
-class KeyPointMatcherDistance : public Distance
+class KeyPointMatcherDistance : public UntrainableDistance
 {
     Q_OBJECT
     Q_PROPERTY(QString matcher READ get_matcher WRITE set_matcher RESET reset_matcher STORED false)

--- a/openbr/plugins/openbr_internal.h
+++ b/openbr/plugins/openbr_internal.h
@@ -501,6 +501,18 @@ typedef QVector<Neighbors> Neighborhood;
 
 BR_EXPORT bool compareNeighbors(const Neighbor &a, const Neighbor &b);
 
+/*!
+ * \brief A br::Distance that does not require training data.
+ */
+class BR_EXPORT UntrainableDistance : public Distance
+{
+    Q_OBJECT
+
+private:
+    bool trainable() { return false; }
+    void train(const TemplateList &data) { (void) data; }
+};
+
 }
 
 #endif // OPENBR_INTERNAL_H

--- a/openbr/plugins/pp5.cpp
+++ b/openbr/plugins/pp5.cpp
@@ -407,7 +407,7 @@ BR_REGISTER(Transform, PP5EnrollTransform)
  * \author E. Taborsky \cite mmtaborsky
  * \note PP5 distance is known to be asymmetric
  */
-class PP5CompareDistance : public Distance
+class PP5CompareDistance : public UntrainableDistance
                          , public PP5Context
 {
     Q_OBJECT

--- a/openbr/plugins/quantize.cpp
+++ b/openbr/plugins/quantize.cpp
@@ -251,7 +251,7 @@ QVector<Mat> ProductQuantizationLUTs;
  * \brief Distance in a product quantized space \cite jegou11
  * \author Josh Klontz \cite jklontz
  */
-class ProductQuantizationDistance : public Distance
+class ProductQuantizationDistance : public UntrainableDistance
 {
     Q_OBJECT
     Q_PROPERTY(bool bayesian READ get_bayesian WRITE set_bayesian RESET reset_bayesian STORED false)
@@ -291,7 +291,7 @@ BR_REGISTER(Distance, ProductQuantizationDistance)
  * \brief Recurively computed distance in a product quantized space
  * \author Josh Klontz \cite jklontz
  */
-class RecursiveProductQuantizationDistance : public Distance
+class RecursiveProductQuantizationDistance : public UntrainableDistance
 {
     Q_OBJECT
     Q_PROPERTY(float t READ get_t WRITE set_t RESET reset_t STORED false)

--- a/openbr/plugins/sentence.cpp
+++ b/openbr/plugins/sentence.cpp
@@ -39,7 +39,7 @@ BR_REGISTER(Transform, SentenceTransform)
  * \brief Distance between sentences
  * \author Josh Klontz \cite jklontz
  */
-class SentenceSimilarityDistance : public Distance
+class SentenceSimilarityDistance : public UntrainableDistance
 {
     Q_OBJECT
 

--- a/openbr/plugins/turk.cpp
+++ b/openbr/plugins/turk.cpp
@@ -138,7 +138,7 @@ BR_REGISTER(Transform, TurkClassifierTransform)
  * \brief Unmaps Turk HITs to be compared against query mats
  * \author Scott Klum \cite sklum
  */
-class TurkDistance : public Distance
+class TurkDistance : public UntrainableDistance
 {
     Q_OBJECT
     Q_PROPERTY(QString key READ get_key WRITE set_key RESET reset_key)

--- a/openbr/plugins/validate.cpp
+++ b/openbr/plugins/validate.cpp
@@ -139,7 +139,7 @@ BR_REGISTER(Transform, CrossValidateTransform)
  * \brief Cross validate a distance metric.
  * \author Josh Klontz \cite jklontz
  */
-class CrossValidateDistance : public Distance
+class CrossValidateDistance : public UntrainableDistance
 {
     Q_OBJECT
 
@@ -159,7 +159,7 @@ BR_REGISTER(Distance, CrossValidateDistance)
  * \brief Checks target metadata against filters.
  * \author Josh Klontz \cite jklontz
  */
-class FilterDistance : public Distance
+class FilterDistance : public UntrainableDistance
 {
     Q_OBJECT
 
@@ -190,7 +190,7 @@ BR_REGISTER(Distance, FilterDistance)
  * \brief Checks target metadata against query metadata.
  * \author Scott Klum \cite sklum
  */
-class MetadataDistance : public Distance
+class MetadataDistance : public UntrainableDistance
 {
     Q_OBJECT
 
@@ -241,7 +241,7 @@ BR_REGISTER(Distance, MetadataDistance)
  * \brief Sets distance to -FLOAT_MAX if a target template has/doesn't have a key.
  * \author Scott Klum \cite sklum
  */
-class RejectDistance : public Distance
+class RejectDistance : public UntrainableDistance
 {
     Q_OBJECT
 


### PR DESCRIPTION
@caotto @sklum @bklare The following PR introduces `virtual bool br::Distance::trainable()` and `br::UntrainableDistance`, the distance helper class analogy to `br::UntrainableTransform`. The purpose of this PR is to avoid projecting the training set through the enrollment pipeline, only to pass it to a distance that doesn't require any training. This is a substantial time saver for algorithms with untrainable distance metrics and large training sets.