### PR TITLE
Eval landmark improvements

### DIFF
--- a/app/br/br.cpp
+++ b/app/br/br.cpp
@@ -163,8 +163,8 @@ public:
                 check((parc >= 2) && (parc <= 6), "Incorrect parameter count for 'evalDetection'.");
                 br_eval_detection(parv[0], parv[1], parc >= 3 ? parv[2] : "", parc >= 4 ? atoi(parv[3]) : 0, parc >= 5 ? atoi(parv[4]) : 0, parc == 6 ? atoi(parv[5]) : 0);
             } else if (!strcmp(fun, "evalLandmarking")) {
-                check((parc >= 2) && (parc <= 5), "Incorrect parameter count for 'evalLandmarking'.");
-                br_eval_landmarking(parv[0], parv[1], parc >= 3 ? parv[2] : "", parc >= 4 ? atoi(parv[3]) : 0, parc >= 5 ? atoi(parv[4]) : 1);
+                check((parc >= 2) && (parc <= 6), "Incorrect parameter count for 'evalLandmarking'.");
+                br_eval_landmarking(parv[0], parv[1], parc >= 3 ? parv[2] : "", parc >= 4 ? atoi(parv[3]) : 0, parc >= 5 ? atoi(parv[4]) : 1,  parc >= 6 ? atoi(parv[5]) : 0);
             } else if (!strcmp(fun, "evalRegression")) {
                 check(parc >= 2 && parc <= 4, "Incorrect parameter count for 'evalRegression'.");
                 br_eval_regression(parv[0], parv[1], parc >= 3 ? parv[2] : "", parc >= 4 ? parv[3] : "");

--- a/app/br/br.cpp
+++ b/app/br/br.cpp
@@ -163,8 +163,8 @@ public:
                 check((parc >= 2) && (parc <= 6), "Incorrect parameter count for 'evalDetection'.");
                 br_eval_detection(parv[0], parv[1], parc >= 3 ? parv[2] : "", parc >= 4 ? atoi(parv[3]) : 0, parc >= 5 ? atoi(parv[4]) : 0, parc == 6 ? atoi(parv[5]) : 0);
             } else if (!strcmp(fun, "evalLandmarking")) {
-                check((parc >= 2) && (parc <= 6), "Incorrect parameter count for 'evalLandmarking'.");
-                br_eval_landmarking(parv[0], parv[1], parc >= 3 ? parv[2] : "", parc >= 4 ? atoi(parv[3]) : 0, parc >= 5 ? atoi(parv[4]) : 1,  parc >= 6 ? atoi(parv[5]) : 0);
+                check((parc >= 2) && (parc <= 7), "Incorrect parameter count for 'evalLandmarking'.");
+                br_eval_landmarking(parv[0], parv[1], parc >= 3 ? parv[2] : "", parc >= 4 ? atoi(parv[3]) : 0, parc >= 5 ? atoi(parv[4]) : 1,  parc >= 6 ? atoi(parv[5]) : 0, parc >= 7 ? atoi(parv[6]) : 5);
             } else if (!strcmp(fun, "evalRegression")) {
                 check(parc >= 2 && parc <= 4, "Incorrect parameter count for 'evalRegression'.");
                 br_eval_regression(parv[0], parv[1], parc >= 3 ? parv[2] : "", parc >= 4 ? parv[3] : "");

--- a/app/br/br.cpp
+++ b/app/br/br.cpp
@@ -264,7 +264,7 @@ private:
                "-evalClassification <predicted_gallery> <truth_gallery> <predicted property name> <ground truth proprty name>\n"
                "-evalClustering <clusters> <gallery>\n"
                "-evalDetection <predicted_gallery> <truth_gallery> [{csv}] [{normalize}] [{minSize}]\n"
-               "-evalLandmarking <predicted_gallery> <truth_gallery> [{csv} [<normalization_index_a> <normalization_index_b>]]\n"
+               "-evalLandmarking <predicted_gallery> <truth_gallery> [{csv} [<normalization_index_a> <normalization_index_b>] [sample_index] [total_examples]]\n"
                "-evalRegression <predicted_gallery> <truth_gallery> <predicted property name> <ground truth property name>\n"
                "-assertEval <simmat> <mask> <accuracy>\n"
                "-plotDetection <file> ... <file> {destination}\n"

--- a/openbr/core/eval.cpp
+++ b/openbr/core/eval.cpp
@@ -1040,7 +1040,7 @@ static void projectAndWrite(Transform *t, const Template &src, const QString &fi
     OpenCVUtils::saveImage(dst.m(),filePath);
 }
 
-float EvalLandmarking(const QString &predictedGallery, const QString &truthGallery, const QString &csv, int normalizationIndexA, int normalizationIndexB, int sampleIndex)
+float EvalLandmarking(const QString &predictedGallery, const QString &truthGallery, const QString &csv, int normalizationIndexA, int normalizationIndexB, int sampleIndex, int totalExamples)
 {
     qDebug("Evaluating landmarking of %s against %s", qPrintable(predictedGallery), qPrintable(truthGallery));
     TemplateList predicted(TemplateList::fromGallery(predictedGallery));
@@ -1109,7 +1109,6 @@ float EvalLandmarking(const QString &predictedGallery, const QString &truthGalle
 
     QScopedPointer<Transform> t(Transform::make("Open+Draw(rects=false)",NULL));
 
-    const int totalExamples = 10;
     for (int i=0; i<totalExamples; i++) {
         QString filePath = "landmarking_examples_truth/"+truth[exampleIndices[i].second].file.fileName();
         projectAndWrite(t.data(), truth[exampleIndices[i].second],filePath);

--- a/openbr/core/eval.cpp
+++ b/openbr/core/eval.cpp
@@ -1097,16 +1097,16 @@ float EvalLandmarking(const QString &predictedGallery, const QString &truthGalle
     for (int i=0; i<totalExamples; i++) {
         Enroll(truth[exampleIndices[i].second],"landmarking_examples_truth");
         lines.append("EXT,landmarking_examples_truth/"+truth[exampleIndices[i].second].file.fileName()+","+QString::number(exampleIndices[i].first));
-        Enroll(predicted[exampleIndices[i].second],"landmarking_examples_prediced");
-        lines.append("EXP,landmarking_examples_prediced/"+predicted[exampleIndices[i].second].file.fileName()+","+QString::number(exampleIndices[i].first));
+        Enroll(predicted[exampleIndices[i].second],"landmarking_examples_predicted");
+        lines.append("EXP,landmarking_examples_predicted/"+predicted[exampleIndices[i].second].file.fileName()+","+QString::number(exampleIndices[i].first));
 
     }
 
     for (int i=exampleIndices.size()-1; i>exampleIndices.size()-totalExamples-1; i--) {
         Enroll(truth[exampleIndices[i].second],"landmarking_examples_truth");
         lines.append("EXT,landmarking_examples_truth/"+truth[exampleIndices[i].second].file.fileName()+","+QString::number(exampleIndices[i].first));
-        Enroll(predicted[exampleIndices[i].second],"landmarking_examples_prediced");
-        lines.append("EXP,landmarking_examples_prediced/"+predicted[exampleIndices[i].second].file.fileName()+","+QString::number(exampleIndices[i].first));
+        Enroll(predicted[exampleIndices[i].second],"landmarking_examples_predicted");
+        lines.append("EXP,landmarking_examples_predicted/"+predicted[exampleIndices[i].second].file.fileName()+","+QString::number(exampleIndices[i].first));
 
     }
 

--- a/openbr/core/eval.cpp
+++ b/openbr/core/eval.cpp
@@ -1095,12 +1095,24 @@ float EvalLandmarking(const QString &predictedGallery, const QString &truthGalle
     QStringList lines;
     lines.append("Plot,X,Y");
 
+    // Sample
     QFile exampleFile("landmarking_examples");
     QtUtils::touchDir(exampleFile);
     lines.append("EX,landmarking_examples/"+truth[sampleIndex].file.fileName()+","+QString::number(truth[sampleIndex].file.points().size()));
 
     // Alternatively, can we just pass this through a predetermined transform and write?
     Enroll(truth[sampleIndex],"landmarking_examples");
+
+    // Error table
+    for (int i=0; i<averagePointErrors.size(); i++) {
+        lines.append(QString("AE,%1,%2").arg(QString::number(i),QString::number(averagePointErrors[i], 'f', 3)));
+        lines.append(QString("ME,%1,%2").arg(QString::number(i),QString::number(medianPointErrors[i], 'f', 3)));
+        lines.append(QString("SE,%1,%2").arg(QString::number(i),QString::number(stddevPointErrors[i], 'f', 3)));
+    }
+
+    lines.append(QString("AE,%1,%2").arg(QString::number(averagePointErrors.size()),QString::number(averagePointError, 'f', 3)));
+    lines.append(QString("ME,%1,%2").arg(QString::number(averagePointErrors.size()),QString::number(medianPointError, 'f', 3)));
+    lines.append(QString("SE,%1,%2").arg(QString::number(averagePointErrors.size()),QString::number(stddevPointError, 'f', 3)));
 
     for (int i=0; i<pointErrors.size(); i++) {
         const QList<float> &pointError = pointErrors[i];
@@ -1112,12 +1124,6 @@ float EvalLandmarking(const QString &predictedGallery, const QString &truthGalle
     lines.append(QString("AvgError,0,%1").arg(averagePointError));
 
     QtUtils::writeFile(csv, lines);
-
-    for (int i=0; i<averagePointErrors.size(); i++) {
-        qDebug("Average Error for point %d: %.3f", i, averagePointErrors[i]);
-        qDebug("Median Error for point %d: %.3f", i, medianPointErrors[i]);
-        qDebug("Standard Deviation of Error for point %d: %.3f", i, stddevPointErrors[i]);
-    }
 
     qDebug("Average Error for all Points: %.3f", averagePointError);
     qDebug("Average Median Error for all Points: %.3f", medianPointError);

--- a/openbr/core/eval.h
+++ b/openbr/core/eval.h
@@ -31,7 +31,7 @@ namespace br
 
     void EvalClassification(const QString &predictedGallery, const QString &truthGallery, QString predictedProperty = "", QString truthProperty = "");
     float EvalDetection(const QString &predictedGallery, const QString &truthGallery, const QString &csv = "", bool normalize = false, int minSize = 0, int maxSize = 0); // Return average overlap
-    float EvalLandmarking(const QString &predictedGallery, const QString &truthGallery, const QString &csv = "", int normalizationIndexA = 0, int normalizationIndexB = 1); // Return average error
+    float EvalLandmarking(const QString &predictedGallery, const QString &truthGallery, const QString &csv = "", int normalizationIndexA = 0, int normalizationIndexB = 1, int sampleIndex = 0); // Return average error
     void EvalRegression(const QString &predictedGallery, const QString &truthGallery, QString predictedProperty = "", QString truthProperty = "");
 }
 

--- a/openbr/core/eval.h
+++ b/openbr/core/eval.h
@@ -31,7 +31,7 @@ namespace br
 
     void EvalClassification(const QString &predictedGallery, const QString &truthGallery, QString predictedProperty = "", QString truthProperty = "");
     float EvalDetection(const QString &predictedGallery, const QString &truthGallery, const QString &csv = "", bool normalize = false, int minSize = 0, int maxSize = 0); // Return average overlap
-    float EvalLandmarking(const QString &predictedGallery, const QString &truthGallery, const QString &csv = "", int normalizationIndexA = 0, int normalizationIndexB = 1, int sampleIndex = 0); // Return average error
+    float EvalLandmarking(const QString &predictedGallery, const QString &truthGallery, const QString &csv = "", int normalizationIndexA = 0, int normalizationIndexB = 1, int sampleIndex = 0, int totalExamples = 5); // Return average error
     void EvalRegression(const QString &predictedGallery, const QString &truthGallery, QString predictedProperty = "", QString truthProperty = "");
 }
 

--- a/openbr/core/plot.cpp
+++ b/openbr/core/plot.cpp
@@ -469,16 +469,18 @@ bool PlotLandmarking(const QStringList &files, const File &destination, bool sho
     qDebug("Plotting %d landmarking file(s) to %s", files.size(), qPrintable(destination));
     RPlot p(files, destination, false);
 
-    p.file.write("# Split data into individual plots\n"
+    p.file.write(qPrintable(QString("# Split data into individual plots\n"
                  "plot_index = which(names(data)==\"Plot\")\n"
                  "Box <- data[grep(\"Box\",data$Plot),-c(1)]\n"
                  "EX <- data[grep(\"EX\",data$Plot),-c(1)]\n"
+                 "AE <- data[grep(\"AE\",data$Plot),-c(1)]\n"
+                 "ME <- data[grep(\"ME\",data$Plot),-c(1)]\n"
+                 "SE <- data[grep(\"SE\",data$Plot),-c(1)]\n"
                  "EX$X <- as.character(EX$X)\n"
                  "EX$Y <- as.character(EX$Y)\n"
                  "rm(data)\n"
-                 "\n");
+                 "\n")));
 
-    // Load in the relevant libraries
     p.file.write(qPrintable(QString("if (nrow(EX) != 0) { \
                                     \n\tlibrary(jpeg) \
                                     \n\tlibrary(png) \
@@ -530,6 +532,18 @@ bool PlotLandmarking(const QStringList &files, const File &destination, bool sho
                                     + annotation_custom(g, xmin=-Inf, xmax=Inf, ymin=-Inf, ymax=Inf) \
                                     + theme(axis.line=element_blank(), axis.title.y=element_blank(), axis.text.x=element_blank(), axis.text.y=element_blank(), line=element_blank(), axis.ticks=element_blank(), panel.background=element_blank()) \
                                     + labs(title=\"Sample Landmarks\") + xlab(sprintf(\"Total Landmarks: %s\",points)))\n\t\t}}\n")));
+
+    p.file.write(qPrintable(QString("\n"
+                 "# Code to format error table\n"
+                 "l <- list(AE$Y,ME$Y,SE$Y)\n"
+                 "mat <- matrix(do.call(rbind, l),nrow=nrow(AE),ncol=3,byrow=TRUE)\n"
+                 "colnames(mat) <- c(\"Mean\",\"Median\",\"Std. Dev.\") \n"
+                 "rownames(mat) <- c(seq(0,nrow(AE)-2),\"Average\")\n"
+                 "ETable <- as.table(mat)\n")));
+
+    p.file.write(qPrintable(QString("\n"
+                       "print(textplot(ETable))\n"
+                       "print(title(expression(atop(\"Landmark Error Rates\", atop(italic(\"Average Normalization Distance: 91.419 (pixels)\"))))))\n")));
 
     p.file.write(qPrintable(QString("ggplot(Box, aes(Y,%1%2))").arg(p.major.size > 1 ? QString(", colour=%1").arg(p.major.header) : QString(),
                                                                     p.minor.size > 1 ? QString(", linetype=%1").arg(p.minor.header) : QString()) +

--- a/openbr/core/plot.cpp
+++ b/openbr/core/plot.cpp
@@ -546,11 +546,13 @@ bool PlotLandmarking(const QStringList &files, const File &destination, bool sho
                                     "algs <- unique(Box$%1)\n"
                                     "algs <- algs[!duplicated(algs)]\n"
                                     "print(plotImage(sample[[1]],\"Sample Landmarks\",sprintf(\"Total Landmarks: %s\",sample[[1]]$value))) \n"
-                                    "for (j in 1:length(algs)) {\n"
-                                    "truthSample <- readData(EXT[EXT$. == algs[[j]],])\n"
-                                    "predictedSample <- readData(EXP[EXP$. == algs[[j]],])\n"
-                                    "\tfor (i in 1:length(predictedSample)) {\n"
-                                    "\t\tmultiplot(plotImage(predictedSample[[i]],sprintf(\"%s\\nPredicted Landmarks\",algs[[j]]),sprintf(\"Average Landmark Error: %.3f\",predictedSample[[i]]$value)),plotImage(truthSample[[i]],\"Ground Truth\\nLandmarks\",\"\"),cols=2)\n"
+                                    "if (nrow(EXT) != 0 && nrow(EXP)) {\n"
+                                    "\tfor (j in 1:length(algs)) {\n"
+                                    "\ttruthSample <- readData(EXT[EXT$. == algs[[j]],])\n"
+                                    "\tpredictedSample <- readData(EXP[EXP$. == algs[[j]],])\n"
+                                    "\t\tfor (i in 1:length(predictedSample)) {\n"
+                                    "\t\t\tmultiplot(plotImage(predictedSample[[i]],sprintf(\"%s\\nPredicted Landmarks\",algs[[j]]),sprintf(\"Average Landmark Error: %.3f\",predictedSample[[i]]$value)),plotImage(truthSample[[i]],\"Ground Truth\\nLandmarks\",\"\"),cols=2)\n"
+                                    "\t\t}\n"
                                     "\t}\n"
                                     "}\n").arg(p.major.size > 1 ? p.major.header : (p.minor.header.isEmpty() ? p.major.header : p.minor.header))));
 

--- a/openbr/openbr.cpp
+++ b/openbr/openbr.cpp
@@ -134,9 +134,9 @@ float br_eval_detection(const char *predicted_gallery, const char *truth_gallery
     return EvalDetection(predicted_gallery, truth_gallery, csv, normalize, minSize, maxSize);
 }
 
-float br_eval_landmarking(const char *predicted_gallery, const char *truth_gallery, const char *csv, int normalization_index_a, int normalization_index_b)
+float br_eval_landmarking(const char *predicted_gallery, const char *truth_gallery, const char *csv, int normalization_index_a, int normalization_index_b, int sample_index)
 {
-    return EvalLandmarking(predicted_gallery, truth_gallery, csv, normalization_index_a, normalization_index_b);
+    return EvalLandmarking(predicted_gallery, truth_gallery, csv, normalization_index_a, normalization_index_b, sample_index);
 }
 
 void br_eval_regression(const char *predicted_gallery, const char *truth_gallery, const char *predicted_property, const char *truth_property)

--- a/openbr/openbr.cpp
+++ b/openbr/openbr.cpp
@@ -134,9 +134,9 @@ float br_eval_detection(const char *predicted_gallery, const char *truth_gallery
     return EvalDetection(predicted_gallery, truth_gallery, csv, normalize, minSize, maxSize);
 }
 
-float br_eval_landmarking(const char *predicted_gallery, const char *truth_gallery, const char *csv, int normalization_index_a, int normalization_index_b, int sample_index)
+float br_eval_landmarking(const char *predicted_gallery, const char *truth_gallery, const char *csv, int normalization_index_a, int normalization_index_b, int sample_index, int total_examples)
 {
-    return EvalLandmarking(predicted_gallery, truth_gallery, csv, normalization_index_a, normalization_index_b, sample_index);
+    return EvalLandmarking(predicted_gallery, truth_gallery, csv, normalization_index_a, normalization_index_b, sample_index, total_examples);
 }
 
 void br_eval_regression(const char *predicted_gallery, const char *truth_gallery, const char *predicted_property, const char *truth_property)

--- a/openbr/openbr.h
+++ b/openbr/openbr.h
@@ -214,8 +214,9 @@ BR_EXPORT float br_eval_detection(const char *predicted_gallery, const char *tru
  * \param csv Optional \c .csv file to contain performance metrics.
  * \param normalization_index_a Optional first index in the list of points to use for normalization.
  * \param normalization_index_b Optional second index in the list of points to use for normalization.
+ * \param sample_index Optional index for sample landmark image in ground truth gallery.
  */
-BR_EXPORT float br_eval_landmarking(const char *predicted_gallery, const char *truth_gallery, const char *csv = "", int normalization_index_a = 0, int normalization_index_b = 1);
+BR_EXPORT float br_eval_landmarking(const char *predicted_gallery, const char *truth_gallery, const char *csv = "", int normalization_index_a = 0, int normalization_index_b = 1, int sample_index = 0);
 
 /*!
  * \brief Evaluates regression accuracy to disk.

--- a/openbr/openbr.h
+++ b/openbr/openbr.h
@@ -215,8 +215,9 @@ BR_EXPORT float br_eval_detection(const char *predicted_gallery, const char *tru
  * \param normalization_index_a Optional first index in the list of points to use for normalization.
  * \param normalization_index_b Optional second index in the list of points to use for normalization.
  * \param sample_index Optional index for sample landmark image in ground truth gallery.
+ * \param total_examples Optional number of accurate and inaccurate examples to display.
  */
-BR_EXPORT float br_eval_landmarking(const char *predicted_gallery, const char *truth_gallery, const char *csv = "", int normalization_index_a = 0, int normalization_index_b = 1, int sample_index = 0);
+BR_EXPORT float br_eval_landmarking(const char *predicted_gallery, const char *truth_gallery, const char *csv = "", int normalization_index_a = 0, int normalization_index_b = 1, int sample_index = 0, int total_examples = 5);
 
 /*!
  * \brief Evaluates regression accuracy to disk.

--- a/openbr/plugins/draw.cpp
+++ b/openbr/plugins/draw.cpp
@@ -42,11 +42,15 @@ class DrawTransform : public UntrainableTransform
     Q_PROPERTY(bool rects READ get_rects WRITE set_rects RESET reset_rects STORED false)
     Q_PROPERTY(bool inPlace READ get_inPlace WRITE set_inPlace RESET reset_inPlace STORED false)
     Q_PROPERTY(int lineThickness READ get_lineThickness WRITE set_lineThickness RESET reset_lineThickness STORED false)
+    Q_PROPERTY(bool named READ get_named WRITE set_named RESET reset_named STORED false)
+    Q_PROPERTY(bool location READ get_location WRITE set_location RESET reset_location STORED false)
     BR_PROPERTY(bool, verbose, false)
     BR_PROPERTY(bool, points, true)
     BR_PROPERTY(bool, rects, true)
     BR_PROPERTY(bool, inPlace, false)
     BR_PROPERTY(int, lineThickness, 1)
+    BR_PROPERTY(bool, named, true)
+    BR_PROPERTY(bool, location, true)
 
     void project(const Template &src, Template &dst) const
     {
@@ -55,11 +59,12 @@ class DrawTransform : public UntrainableTransform
         dst.m() = inPlace ? src.m() : src.m().clone();
 
         if (points) {
-            const QList<Point2f> pointsList = OpenCVUtils::toPoints(src.file.namedPoints() + src.file.points());
+            const QList<Point2f> pointsList = (named) ? OpenCVUtils::toPoints(src.file.points()+src.file.namedPoints()) : OpenCVUtils::toPoints(src.file.points());
             for (int i=0; i<pointsList.size(); i++) {
                 const Point2f &point = pointsList[i];
                 circle(dst, point, 3, color, -1);
-                if (verbose) putText(dst, QString("%1,(%2,%3)").arg(QString::number(i),QString::number(point.x),QString::number(point.y)).toStdString(), point, FONT_HERSHEY_SIMPLEX, 0.5, verboseColor, 1);
+                QString label = (location) ? QString("%1,(%2,%3)").arg(QString::number(i),QString::number(point.x),QString::number(point.y)) : QString("%1").arg(QString::number(i));
+                if (verbose) putText(dst, label.toStdString(), point, FONT_HERSHEY_SIMPLEX, 0.5, verboseColor, 1);
             }
         }
         if (rects) {


### PR DESCRIPTION
This branch introduces functionality to evalLandmarking including:

* A sample image with ground truth landmarks drawn and labeled with their index that corresponds to later figures.
* Accurate and inaccurate testing examples.
* Table of average error rates for each landmark with confidence intervals.
* Reordered results in the normalized error plots such that they are sequential, as opposed to ordered by factor.
* Added options to draw to control the display of landmarks when using the `verbose` flag and to optionally display named points.

There is some duplication here with respect to the R code, which I can eliminate if this bothers anyone.

@bhklein @jklontz take a look?

Example posted in Slack.

Solves #302.