### PR TITLE
Updates to stored transform handling

### DIFF
--- a/openbr/openbr_plugin.cpp
+++ b/openbr/openbr_plugin.cpp
@@ -1413,6 +1413,13 @@ Transform *Transform::make(QString str, QObject *parent)
     if (str.startsWith('(') && str.endsWith(')'))
         return make(str.mid(1, str.size()-2), parent);
 
+    // Base name not found? Try constructing it via LoadStore
+    if (!Factory<Transform>::names().contains(parsed.suffix())) {
+        Transform *tform = make("<"+parsed.suffix()+">", parent);
+        applyAdditionalProperties(parsed, tform);
+        return tform;
+    }
+
     //! [Construct the root transform]
     Transform *transform = Factory<Transform>::make("." + str);
     //! [Construct the root transform]

--- a/openbr/openbr_plugin.cpp
+++ b/openbr/openbr_plugin.cpp
@@ -786,13 +786,63 @@ void Object::load(QDataStream &stream)
     init();
 }
 
-bool Object::setPropertyRecursive(const QString &name, QVariant value)
+bool Object::setExistingProperty(const QString &name, QVariant value)
 {
     if (this->metaObject()->indexOfProperty(qPrintable(name)) == -1)
         return false;
     setProperty(name, value);
     init();
     return true;
+}
+
+QList<Object *> Object::getChildren() const
+{
+    QList<Object *> output;
+    for (int i=0; i < metaObject()->propertyCount(); i++) {
+        const char *prop_name = metaObject()->property(i).name();
+        const QVariant &variant = this->property(prop_name);
+
+        if (variant.canConvert<Transform *>()) {
+            Transform *tform = variant.value<Transform *>();
+            if (tform)
+                output.append((Object* ) variant.value<Transform *>());
+        }
+        else if (variant.canConvert<QList<Transform *> >()) {
+            foreach (const Transform *tform, variant.value<QList<Transform *> >()) {
+                if (tform)
+                    output.append((Object *) tform);
+            }
+        }
+        else if (variant.canConvert<Distance *>()) {
+            Distance *dist = variant.value<Distance *>();
+            if (dist)
+                output.append((Object* ) variant.value<Distance *>());
+        }
+        else if (variant.canConvert<QList<Distance *> >()) {
+            foreach (const Distance *dist, variant.value<QList<Distance *> >()) {
+                if (dist)
+                    output.append((Object *) dist);
+            }
+        }
+    }
+    return output;
+}
+
+bool Object::setPropertyRecursive(const QString &name, QVariant value)
+{
+    // collect children
+    bool res = setExistingProperty(name, value);
+    if (res)
+        return true;
+
+    QList<Object *> children = getChildren();
+    foreach (Object *obj, children) {
+        if (obj->setPropertyRecursive(name, value)) {
+            init();
+            return true;
+        }
+    }
+    return false;
 }
 
 void Object::setProperty(const QString &name, QVariant value)
@@ -1408,24 +1458,9 @@ void Transform::project(const TemplateList &src, TemplateList &dst) const
     futures.waitForFinished();
 }
 
-QList<Transform *> Transform::getChildren() const
-{
-    QList<Transform *> output;
-    for (int i=0; i < metaObject()->propertyCount(); i++) {
-        const char *prop_name = metaObject()->property(i).name();
-        const QVariant &variant = this->property(prop_name);
-
-        if (variant.canConvert<Transform *>())
-            output.append(variant.value<Transform *>());
-        if (variant.canConvert<QList<Transform *> >())
-            output.append(variant.value<QList<Transform *> >());
-    }
-    return output;
-}
-
 TemplateEvent *Transform::getEvent(const QString &name)
 {
-    foreach (Transform *child, getChildren()) {
+    foreach (Transform *child, getChildren<Transform>()) {
         TemplateEvent *probe = child->getEvent(name);
         if (probe)
             return probe;

--- a/openbr/openbr_plugin.h
+++ b/openbr/openbr_plugin.h
@@ -603,6 +603,22 @@ public:
     
     void setProperty(const QString &name, QVariant value); /*!< \brief Overload of QObject::setProperty to handle OpenBR data types. */
     virtual bool setPropertyRecursive(const QString &name, QVariant value); /*!< \brief Recursive version of setProperty, try to set the property on this object, or its children, returns true if successful. */
+    bool setExistingProperty(const QString &name, QVariant value); /*! <\brief attempt to set property 'name' on this object. If name is not a pre-declared property, return false */
+
+    virtual QList<Object *> getChildren() const; /*!< \brief retrieve children of this object, default version scans properties, subclasses which do not sotre their children as properties must overload. */
+
+    template<typename T>
+    QList<T *> getChildren() const
+    {
+        QList<Object *> children = getChildren();
+        QList<T *> output;
+        foreach(Object *obj, children) {
+            T *temp = dynamic_cast<T *>(obj);
+            if (temp != NULL)
+                output.append(temp);
+        }
+        return output;
+    }
 
     static QStringList parse(const QString &string, char split = ','); /*!< \brief Splits the string while respecting lexical scoping of <tt>()</tt>, <tt>[]</tt>, <tt>\<\></tt>, and <tt>{}</tt>. */
 
@@ -1275,12 +1291,6 @@ public:
      * \brief Recursively retrieve a named event, returns NULL if an event is not found.
      */
     virtual TemplateEvent *getEvent(const QString &name);
-
-    /*!
-     * \brief Get a list of child transforms of this transform, child transforms are considered to be
-     * any transforms stored as properties of this transform.
-     */
-    QList<Transform *> getChildren() const;
 
     static Transform *deserialize(QDataStream &stream)
     {

--- a/openbr/plugins/independent.cpp
+++ b/openbr/plugins/independent.cpp
@@ -138,9 +138,10 @@ class IndependentTransform : public MetaTransform
         return transform->description(expanded);
     }
 
+    // can't use general setPropertyRecursive because of transforms oddness
     bool setPropertyRecursive(const QString &name, QVariant value)
     {
-        if (br::Object::setPropertyRecursive(name, value))
+        if (br::Object::setExistingProperty(name, value))
             return true;
 
         if (!transform->setPropertyRecursive(name, value))

--- a/openbr/plugins/meta.cpp
+++ b/openbr/plugins/meta.cpp
@@ -529,11 +529,11 @@ public:
         return res;
     }
 
-    bool setPropertyRecursive(const QString &name, QVariant value)
+    QList<Object *> getChildren() const
     {
-        if (br::Object::setPropertyRecursive(name, value))
-            return true;
-        return transform->setPropertyRecursive(name, value);
+        QList<Object *> rval;
+        rval.append(transform);
+        return rval;
     }
 private:
 

--- a/openbr/plugins/meta.cpp
+++ b/openbr/plugins/meta.cpp
@@ -540,7 +540,7 @@ private:
     void init()
     {
         if (transform != NULL) return;
-        if (fileName.isEmpty()) baseName = QRegExp("^[a-zA-Z0-9]+$").exactMatch(transformString) ? transformString : QtUtils::shortTextHash(transformString);
+        if (fileName.isEmpty()) baseName = QRegExp("^[_a-zA-Z0-9]+$").exactMatch(transformString) ? transformString : QtUtils::shortTextHash(transformString);
         else baseName = fileName;
         if (!tryLoad())
             transform = make(transformString);

--- a/openbr/plugins/openbr_internal.h
+++ b/openbr/plugins/openbr_internal.h
@@ -227,19 +227,6 @@ public:
         return output;
     }
 
-
-    bool setPropertyRecursive(const QString &name, QVariant value)
-    {
-        if (br::Object::setPropertyRecursive(name, value))
-            return true;
-
-        if (transform->setPropertyRecursive(name, value)) {
-            init();
-            return true;
-        }
-        return false;
-    }
-
     Transform *smartCopy(bool &newTransform)
     {
         if (!timeVarying()) {
@@ -391,21 +378,6 @@ public:
         newTransform = true;
         return output;
     }
-
-    bool setPropertyRecursive(const QString &name, QVariant value)
-    {
-        if (br::Object::setPropertyRecursive(name, value))
-            return true;
-
-        for (int i=0; i < this->transforms.size();i++) {
-            if (transforms[i]->setPropertyRecursive(name, value)) {
-                init();
-                return true;
-            }
-        }
-        return false;
-    }
-
 
 protected:
     bool isTimeVarying;

--- a/openbr/plugins/stream.cpp
+++ b/openbr/plugins/stream.cpp
@@ -1325,9 +1325,10 @@ public:
         return res;
     }
 
+    // can't use general setPropertyRecursive due to special handling of basis
     bool setPropertyRecursive(const QString &name, QVariant value)
     {
-        if (br::Object::setPropertyRecursive(name, value))
+        if (br::Object::setExistingProperty(name, value))
             return true;
 
         for (int i=0; i < basis->transforms.size();i++) {
@@ -1336,6 +1337,12 @@ public:
                 return true;
             }
         }
+
+        if (basis->endPoint->setPropertyRecursive(name, value)) {
+            basis->endPoint->init();
+            return true;
+        }
+
         return false;
     }
 


### PR DESCRIPTION
2 parts here, one is a refactor of setPropertyRecursive, so that the implementation is a little more general. Instead of implementing a method in every Transform with child transforms, the default implementation of setPropertyRecursive looks for Transform * and QList<Transform *> properties automatically. 

There are some limitations to this approach, in particular all transforms which use a QString property to store their child transforms description, rather than storing the child transform as a property still require special casing. It is perhaps worth reconsidering this idiom in general, since by this point using a QString property loses out on both automatic serialization of the child transform, and proper navigation of transform trees via reflection. 


Part 2, is as requested by @sklum, adding support for additional arguments to transforms stored via LoadStore (though the implementation is perhaps more aggressive than anticipated).

Per 9abe69538:
If an unknown transform string is encountered in an algorithm, attempt
to load it via LoadStore, e.g.
"Open+Cascade+landmark_model"
would expand landmark_model to <landmark_model>. Additionally, arguments
supplied to such unknown transforms are set via setPropertyRecursive
e.g.
"Open+Cascade+landmark_model(something=true)"
works.

Also allow _ in model names specified as the first argument to LoadStore

