### PR TITLE
Adding a minimum version requirement for OpenCV (2.4.5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ endforeach()
 set(BR_THIRDPARTY_LIBS ${BR_THIRDPARTY_LIBS} ${Qt5Core_QTMAIN_LIBRARIES})
 
 # Find OpenCV
-find_package(OpenCV REQUIRED)
+find_package(OpenCV 2.4.5 REQUIRED)
 set(OPENCV_DEPENDENCIES opencv_calib3d opencv_core opencv_features2d opencv_flann opencv_gpu opencv_highgui opencv_imgproc opencv_ml opencv_nonfree opencv_objdetect opencv_photo opencv_video)
 set(BR_THIRDPARTY_LIBS ${BR_THIRDPARTY_LIBS} ${OpenCV_LIBS})
 


### PR DESCRIPTION
The build was failing for me because I have multiple versions of OpenCV installed on my system, and the CMake build was just using whatever the default OpenCV was, which in my case was an older version that didn't support some of the cascade API OpenBR was using.

The solution is to give the find_package command a minimum version requirement for OpenCV. I chose version 2.4.5 because that is documented at the following website: http://openbiometrics.org/doxygen/latest/linux_gcc.html