### PR TITLE
Block based model compression scheme

### DIFF
--- a/openbr/core/core.cpp
+++ b/openbr/core/core.cpp
@@ -110,9 +110,11 @@ struct AlgorithmCore
 
     void store(const QString &model) const
     {
-        // Create stream
-        QByteArray data;
-        QDataStream out(&data, QFile::WriteOnly);
+        QtUtils::BlockCompression compressedWrite;
+        QFile outFile(model);
+        compressedWrite.setBasis(&outFile);
+        QDataStream out(&compressedWrite);
+        compressedWrite.open(QFile::WriteOnly);
 
         // Serialize algorithm to stream
         transform->serialize(out);
@@ -131,18 +133,16 @@ struct AlgorithmCore
         if (mode == TransformCompare)
             comparison->serialize(out);
 
-        // Compress and save to file
-        QtUtils::writeFile(model, data, -1);
+        compressedWrite.close();
     }
 
     void load(const QString &model)
     {
-        // Load from file and decompress
-        QByteArray data;
-        QtUtils::readFile(model, data, true);
-
-        // Create stream
-        QDataStream in(&data, QFile::ReadOnly);
+        QtUtils::BlockCompression compressedRead;
+        QFile inFile(model);
+        compressedRead.setBasis(&inFile);
+        QDataStream in(&compressedRead);
+        compressedRead.open(QFile::ReadOnly);
 
         // Load algorithm
         transform = QSharedPointer<Transform>(Transform::deserialize(in));

--- a/openbr/core/qtutils.cpp
+++ b/openbr/core/qtutils.cpp
@@ -543,10 +543,8 @@ void BlockCompression::close()
 {
     // flush output buffer
     if ((openMode() & QIODevice::WriteOnly) && precompressedBlockWriter) {
-        qDebug() << "Serializing final block";
         QByteArray compressedBlock = qCompress(precompressedBlockWriter->buffer(), -1);
         blockWriter << compressedBlock;
-        qDebug() << "Done";
     }
     basis->close();
 }

--- a/openbr/core/qtutils.cpp
+++ b/openbr/core/qtutils.cpp
@@ -500,6 +500,140 @@ QString getAbsolutePath(const QString &filename)
     return QFileInfo(filename).absoluteFilePath();
 }
 
+BlockCompression::BlockCompression(QIODevice *_basis)
+{
+    blockSize = 1000000;
+    setBasis(_basis);
+}
+
+BlockCompression::BlockCompression() { blockSize = 1000000; };
+
+
+bool BlockCompression::open(QIODevice::OpenMode mode)
+{
+    this->setOpenMode(mode);
+    bool res = basis->open(mode);
+//    qDebug() << "basis: " << basis->isReadable() << " write:" << basis->isWritable();
+    if (!res)
+        return false;
+
+    blockReader.setDevice(basis);
+    blockWriter.setDevice(basis);
+
+    if (mode & QIODevice::WriteOnly) {
+        precompressedBlockWriter = new QBuffer;
+        precompressedBlockWriter->open(QIODevice::ReadWrite);
+    }
+    else if (mode & QIODevice::ReadOnly) {
+//        qDebug() << "BLock reader status:" << blockReader.status();
+        QByteArray compressedBlock;
+        blockReader >> compressedBlock;
+//        qDebug() <<" Post read attempt, " << blockReader.status();
+
+        decompressedBlock = qUncompress(compressedBlock);
+//        qDebug() << "Read compressed block: " << compressedBlock.size() << "Expanded to:"  << decompressedBlock.size();
+        decompressedBlockReader.setBuffer(&decompressedBlock);
+        decompressedBlockReader.open(QIODevice::ReadOnly);
+    }
+
+    return true;
+}
+
+void BlockCompression::close()
+{
+    // flush output buffer
+    if ((openMode() & QIODevice::WriteOnly) && precompressedBlockWriter) {
+        qDebug() << "Serializing final block";
+        QByteArray compressedBlock = qCompress(precompressedBlockWriter->buffer(), -1);
+        blockWriter << compressedBlock;
+        qDebug() << "Done";
+    }
+    basis->close();
+}
+
+void BlockCompression::setBasis(QIODevice *_basis)
+{
+    basis = _basis;
+    blockReader.setDevice(basis);
+    blockWriter.setDevice(basis);
+}
+
+// read from current decompressed block, if out of space, read and decompress another
+// block from basis
+qint64 BlockCompression::readData(char *data, qint64 remaining)
+{
+//    qDebug() <<" Reading: " << remaining;
+    qint64 read = 0;
+    while (remaining > 0) {
+        qint64 single_read = decompressedBlockReader.read(data, remaining);
+        if (single_read == -1)
+            qFatal("miss read");
+//            single_read = 0;
+
+
+        remaining -= single_read;
+        read += single_read;
+        data += single_read;
+//        qDebug() << "Read " << single_read << " reamining: "<< remaining;
+
+        // need a new block
+        if (remaining > 0) {
+            QByteArray compressedBlock;
+            blockReader >> compressedBlock;
+            if (compressedBlock.size() == 0) {
+                return read;
+            }
+            decompressedBlock = qUncompress(compressedBlock);
+
+            decompressedBlockReader.close();
+            decompressedBlockReader.setBuffer(&decompressedBlock);
+            decompressedBlockReader.open(QIODevice::ReadOnly);
+        }
+    }
+    return blockReader.atEnd() && !basis->isReadable() ? -1 : read;
+}
+
+bool BlockCompression::isSequential() const
+{
+    return true;
+}
+
+qint64 BlockCompression::writeData(const char *data, qint64 remaining)
+{
+    qint64 written = 0;
+
+    while (remaining > 0) {
+        // how much more can be put in this buffer?
+        qint64 capacity = blockSize - precompressedBlockWriter->pos();
+
+        // don't try to write beyond capacity 
+        qint64 write_size = qMin(capacity, remaining);
+
+        qint64 singleWrite = precompressedBlockWriter->write(data, write_size);
+        // ignore the error case here, we consdier basis's failure mode the real
+        // end case
+        if (singleWrite == -1)
+            singleWrite = 0;
+
+        remaining -= singleWrite;
+        data += singleWrite;
+        written += singleWrite;
+
+        if (remaining > 0) {
+            QByteArray compressedBlock = qCompress(precompressedBlockWriter->buffer(), -1);
+
+            if (compressedBlock.size() != 0)
+                blockWriter << compressedBlock;
+
+            delete precompressedBlockWriter;
+            precompressedBlockWriter = new QBuffer;
+            precompressedBlockWriter->open(QIODevice::ReadWrite);
+        }
+    }
+    return basis->isWritable() ? written : -1;
+}
+
+
 
 }  // namespace QtUtils
 

--- a/openbr/core/qtutils.cpp
+++ b/openbr/core/qtutils.cpp
@@ -502,18 +502,18 @@ QString getAbsolutePath(const QString &filename)
 
 BlockCompression::BlockCompression(QIODevice *_basis)
 {
-    blockSize = 1000000;
+    blockSize = 100000000;
     setBasis(_basis);
 }
 
-BlockCompression::BlockCompression() { blockSize = 1000000; };
+BlockCompression::BlockCompression() { blockSize = 100000000; };
 
 
 bool BlockCompression::open(QIODevice::OpenMode mode)
 {
     this->setOpenMode(mode);
     bool res = basis->open(mode);
-//    qDebug() << "basis: " << basis->isReadable() << " write:" << basis->isWritable();
+
     if (!res)
         return false;
 
@@ -525,13 +525,10 @@ bool BlockCompression::open(QIODevice::OpenMode mode)
         precompressedBlockWriter->open(QIODevice::ReadWrite);
     }
     else if (mode & QIODevice::ReadOnly) {
-//        qDebug() << "BLock reader status:" << blockReader.status();
         QByteArray compressedBlock;
         blockReader >> compressedBlock;
-//        qDebug() <<" Post read attempt, " << blockReader.status();
 
         decompressedBlock = qUncompress(compressedBlock);
-//        qDebug() << "Read compressed block: " << compressedBlock.size() << "Expanded to:"  << decompressedBlock.size();
         decompressedBlockReader.setBuffer(&decompressedBlock);
         decompressedBlockReader.open(QIODevice::ReadOnly);
     }
@@ -560,19 +557,15 @@ void BlockCompression::setBasis(QIODevice *_basis)
 // block from basis
 qint64 BlockCompression::readData(char *data, qint64 remaining)
 {
-//    qDebug() <<" Reading: " << remaining;
     qint64 read = 0;
     while (remaining > 0) {
         qint64 single_read = decompressedBlockReader.read(data, remaining);
         if (single_read == -1)
             qFatal("miss read");
-//            single_read = 0;
-
 
         remaining -= single_read;
         read += single_read;
         data += single_read;
-//        qDebug() << "Read " << single_read << " reamining: "<< remaining;
 
         // need a new block
         if (remaining > 0) {

--- a/openbr/core/qtutils.h
+++ b/openbr/core/qtutils.h
@@ -17,6 +17,7 @@
 #ifndef QTUTILS_QTUTILS_H
 #define QTUTILS_QTUTILS_H
 
+#include <QBuffer>
 #include <QByteArray>
 #include <QDir>
 #include <QFile>
@@ -93,6 +94,38 @@ namespace QtUtils
 
     /**** Rect Utilities ****/
     float overlap(const QRectF &r, const QRectF &s);
+
+    
+    class BlockCompression : public QIODevice
+    {
+    public:
+        BlockCompression(QIODevice *_basis);
+        BlockCompression();
+        int blockSize;
+        QIODevice *basis;
+
+        bool open(QIODevice::OpenMode mode);
+
+        void close();
+
+        void setBasis(QIODevice *_basis);
+
+        QDataStream blockReader;
+        QByteArray decompressedBlock;
+        QBuffer decompressedBlockReader;
+
+        // read from current decompressed block, if out of space, read and decompress another
+        // block from basis
+        qint64 readData(char *data, qint64 remaining);
+
+        bool isSequential() const;
+
+        // write to a QByteArray, when max block sized is reached, compress and write
+        // it to basis
+        QBuffer * precompressedBlockWriter;
+        QDataStream blockWriter;
+        qint64 writeData(const char *data, qint64 remaining);
+    };
 }
 
 #endif // QTUTILS_QTUTILS_H

--- a/openbr/plugins/algorithms.cpp
+++ b/openbr/plugins/algorithms.cpp
@@ -31,7 +31,7 @@ class AlgorithmsInitializer : public Initializer
     void initialize() const
     {
         // Face
-        Globals->abbreviations.insert("FaceRecognition", "FaceDetection+Expand+<FaceRecognitionRegistration>+Expand+<FaceRecognitionExtraction>+<FaceRecognitionEmbedding>+<FaceRecognitionQuantization>+SetMetadata(AlgorithmID,-1):MatchProbability(ByteL1)");
+        Globals->abbreviations.insert("FaceRecognition", "FaceDetection+Expand+FaceRecognitionRegistration+Expand+<FaceRecognitionExtraction>+<FaceRecognitionEmbedding>+<FaceRecognitionQuantization>+SetMetadata(AlgorithmID,-1):MatchProbability(ByteL1)");
         Globals->abbreviations.insert("GenderClassification", "FaceDetection+Expand+<FaceClassificationRegistration>+Expand+<FaceClassificationExtraction>+<GenderClassifier>+Discard");
         Globals->abbreviations.insert("AgeRegression", "FaceDetection+Expand+<FaceClassificationRegistration>+Expand+<FaceClassificationExtraction>+<AgeRegressor>+Discard");
         Globals->abbreviations.insert("FaceQuality", "Open+Expand+Cascade(FrontalFace)+ASEFEyes+Affine(64,64,0.25,0.35)+ImageQuality+Cvt(Gray)+DFFS+Discard");
@@ -92,7 +92,7 @@ class AlgorithmsInitializer : public Initializer
         Globals->abbreviations.insert("DenseHOG", "Gradient+RectRegions(8,8,6,6)+Bin(0,360,8)+Hist(8)");
         Globals->abbreviations.insert("DenseSIFT", "(Grid(10,10)+SIFTDescriptor(12)+ByRow)");
         Globals->abbreviations.insert("DenseSIFT2", "(Grid(5,5)+SIFTDescriptor(12)+ByRow)");
-        Globals->abbreviations.insert("FaceRecognitionRegistration", "(ASEFEyes+Affine(88,88,0.25,0.35)+DownsampleTraining(FTE(DFFS),instances=1))");
+        Globals->abbreviations.insert("FaceRecognitionRegistration", "ASEFEyes+Affine(88,88,0.25,0.35)");
         Globals->abbreviations.insert("FaceRecognitionExtraction", "(Mask+DenseSIFT/DenseLBP+DownsampleTraining(PCA(0.95),instances=1)+Normalize(L2)+Cat)");
         Globals->abbreviations.insert("FaceRecognitionEmbedding", "(Dup(12)+RndSubspace(0.05,1)+DownsampleTraining(LDA(0.98),instances=-2)+Cat+DownsampleTraining(PCA(768),instances=1))");
         Globals->abbreviations.insert("FaceRecognitionQuantization", "(Normalize(L1)+Quantize)");

--- a/openbr/plugins/cascade.cpp
+++ b/openbr/plugins/cascade.cpp
@@ -252,6 +252,8 @@ class CascadeTransform : public MetaTransform
     void init()
     {
         cascadeResource.setResourceMaker(new CascadeResourceMaker(model));
+        if (model == "Ear" || model == "Eye" || model == "FrontalFace" || model == "ProfileFace")
+            this->trainable = false;
     }
     
     // Train transform

--- a/openbr/plugins/meta.cpp
+++ b/openbr/plugins/meta.cpp
@@ -96,17 +96,15 @@ class PipeTransform : public CompositeTransform
 
         int i = 0;
         while (i < transforms.size()) {
-            fprintf(stderr, "\n%s", qPrintable(transforms[i]->objectName()));
-
             // Conditional statement covers likely case that first transform is untrainable
             if (transforms[i]->trainable) {
-                fprintf(stderr, " training...");
+                qDebug() << "Training " << transforms[i]->description() << "\n...";
                 transforms[i]->train(dataLines);
             }
 
             // if the transform is time varying, we can't project it in parallel
             if (transforms[i]->timeVarying()) {
-                fprintf(stderr, "\n%s projecting...", qPrintable(transforms[i]->objectName()));
+                qDebug() << "Projecting " << transforms[i]->description() << "\n...";
                 for (int j=0; j < dataLines.size();j++) {
                     TemplateList junk;
                     splitFTEs(dataLines[j], junk);
@@ -132,7 +130,16 @@ class PipeTransform : public CompositeTransform
                    !transforms[nextTrainableTransform]->timeVarying())
                 nextTrainableTransform++;
 
-            fprintf(stderr, " projecting...");
+            // No more trainable transforms? Don't need any more projects then
+            if (nextTrainableTransform == transforms.size())
+                break;
+
+            fprintf(stderr, "Projecting %s", qPrintable(transforms[i]->description()));
+            for (int j=i+1; j < nextTrainableTransform; j++)
+                fprintf(stderr,"+%s", qPrintable(transforms[j]->description()));
+            fprintf(stderr, "\n...\n");
+            fflush(stderr);
+
             QFutureSynchronizer<void> futures;
             for (int j=0; j < dataLines.size(); j++)
                 futures.addFuture(QtConcurrent::run(this, &PipeTransform::_projectPartial, &dataLines[j], i, nextTrainableTransform));
@@ -512,7 +519,6 @@ class LoadStoreTransform : public MetaTransform
 
 public:
     Transform *transform;
-    QString baseName;
 
     LoadStoreTransform() : transform(NULL) {}
 
@@ -542,8 +548,8 @@ private:
     void init()
     {
         if (transform != NULL) return;
-        if (fileName.isEmpty()) baseName = QRegExp("^[_a-zA-Z0-9]+$").exactMatch(transformString) ? transformString : QtUtils::shortTextHash(transformString);
-        else baseName = fileName;
+        if (fileName.isEmpty()) fileName = QRegExp("^[_a-zA-Z0-9]+$").exactMatch(transformString) ? transformString : QtUtils::shortTextHash(transformString);
+
         if (!tryLoad())
             transform = make(transformString);
         else
@@ -562,9 +568,9 @@ private:
 
         transform->train(data);
 
-        qDebug("Storing %s", qPrintable(baseName));
+        qDebug("Storing %s", qPrintable(fileName));
         QtUtils::BlockCompression compressedOut;
-        QFile fout(baseName);
+        QFile fout(fileName);
         QtUtils::touchDir(fout);
         compressedOut.setBasis(&fout);
 
@@ -606,8 +612,8 @@ private:
 
     QString getFileName() const
     {
-        if (QFileInfo(baseName).exists()) return baseName;
-        const QString file = Globals->sdkPath + "/share/openbr/models/transforms/" + baseName;
+        if (QFileInfo(fileName).exists()) return fileName;
+        const QString file = Globals->sdkPath + "/share/openbr/models/transforms/" + fileName;
         return QFileInfo(file).exists() ? file : QString();
     }
 

--- a/openbr/plugins/quality.cpp
+++ b/openbr/plugins/quality.cpp
@@ -77,6 +77,12 @@ class ImpostorUniquenessMeasureTransform : public Transform
 
 BR_REGISTER(Transform, ImpostorUniquenessMeasureTransform)
 
+
+float KDEPointer(const QList<float> *scores, double x, double h)
+{
+    return Common::KernelDensityEstimation(*scores, x, h);
+}
+
 /* Kernel Density Estimator */
 struct KDE
 {
@@ -85,20 +91,35 @@ struct KDE
     QList<float> bins;
 
     KDE() : min(0), max(1), mean(0), stddev(1) {}
-    KDE(const QList<float> &scores)
+
+    KDE(const QList<float> &scores, bool trainKDE)
     {
         Common::MinMax(scores, &min, &max);
         Common::MeanStdDev(scores, &mean, &stddev);
+
+        if (!trainKDE)
+            return;
+
         double h = Common::KernelDensityBandwidth(scores);
         const int size = 255;
         bins.reserve(size);
-        for (int i=0; i<size; i++)
-            bins.append(Common::KernelDensityEstimation(scores, min + (max-min)*i/(size-1), h));
+
+        QFutureSynchronizer<float> futures;
+
+        for (int i=0; i < size; i++)
+            futures.addFuture(QtConcurrent::run(KDEPointer, &scores, min + (max-min)*i/(size-1), h));
+        futures.waitForFinished();
+
+        foreach(const QFuture<float> & future, futures.futures())
+            bins.append(future.result());
     }
 
     float operator()(float score, bool gaussian = true) const
     {
         if (gaussian) return 1/(stddev*sqrt(2*CV_PI))*exp(-0.5*pow((score-mean)/stddev, 2));
+        if (bins.empty())
+            return -std::numeric_limits<float>::max();
+	
         if (score <= min) return bins.first();
         if (score >= max) return bins.last();
         const float x = (score-min)/(max-min)*bins.size();
@@ -123,8 +144,8 @@ struct MP
 {
     KDE genuine, impostor;
     MP() {}
-    MP(const QList<float> &genuineScores, const QList<float> &impostorScores)
-        : genuine(genuineScores), impostor(impostorScores) {}
+    MP(const QList<float> &genuineScores, const QList<float> &impostorScores, bool trainKDE)
+        : genuine(genuineScores, trainKDE), impostor(impostorScores, trainKDE) {}
     float operator()(float score, bool gaussian = true) const
     {
         const float g = genuine(score, gaussian);
@@ -165,7 +186,7 @@ class MatchProbabilityDistance : public Distance
         const QList<int> labels = src.indexProperty(inputVariable);
         QScopedPointer<MatrixOutput> matrixOutput(MatrixOutput::make(FileList(src.size()), FileList(src.size())));
         distance->compare(src, src, matrixOutput.data());
-
+	
         QList<float> genuineScores, impostorScores;
         genuineScores.reserve(labels.size());
         impostorScores.reserve(labels.size()*labels.size());
@@ -178,8 +199,8 @@ class MatchProbabilityDistance : public Distance
                 else                        impostorScores.append(score);
             }
         }
-
-        mp = MP(genuineScores, impostorScores);
+	
+        mp = MP(genuineScores, impostorScores, !gaussian);
     }
 
     float compare(const Template &target, const Template &query) const


### PR DESCRIPTION
Avoid serialization failures due to uncompressed model size exceeding 2GB. The cause of this issue is that we serialize to an intermediate buffer before writing to disk, and the QByteArray used for this buffer cannot have more than INT_MAX elements. 

This branch avoids the issue by introduce a QIODevice subclass which buffers stream output into fixed size blocks, and compresses those individually rather than using a single buffer for the entire thing. 

This constitutes a binary compatibility break, so all pre-trained models have to be retrained. This is not done yet (FaceRecognition training is done, but gender classification/age regression have not been retrained yet). In spite of this, the code is more or less complete. 

Also, some additional updates to training, geared towards improving training speed and providing more informative output during training.

