### PR TITLE
Gray the same in Read and Cvt

### DIFF
--- a/openbr/plugins/misc.cpp
+++ b/openbr/plugins/misc.cpp
@@ -103,7 +103,7 @@ public:
     enum Mode
     {
         Unchanged = IMREAD_UNCHANGED,
-        Grayscale = IMREAD_GRAYSCALE,
+        Gray      = IMREAD_GRAYSCALE,
         Color     = IMREAD_COLOR,
         AnyDepth  = IMREAD_ANYDEPTH,
         AnyColor  = IMREAD_ANYCOLOR


### PR DESCRIPTION
Suggested change b/c it is annoying to have `Cvt(Gray)` and `Read(Grayscale)`