### PR TITLE
Look for sub-models in directories algorithms were found in 

### DIFF
--- a/openbr/core/core.cpp
+++ b/openbr/core/core.cpp
@@ -138,6 +138,16 @@ struct AlgorithmCore
 
     void load(const QString &model)
     {
+        // since we are loading an existing model, add its path to the search list for submodels
+        // assuming it is not already present.
+        QFileInfo finfo(model);
+        QString path = finfo.absolutePath();
+        QList<QString> paths = Globals->file.getList("modelSearch",QList<QString>() );
+        if (!paths.contains(path)) {
+            paths.append(path);
+            Globals->file.setList("modelSearch", paths);
+        }
+
         QtUtils::BlockCompression compressedRead;
         QFile inFile(model);
         compressedRead.setBasis(&inFile);
@@ -762,5 +772,17 @@ QSharedPointer<br::Distance> br::Distance::fromAlgorithm(const QString &algorith
     return AlgorithmManager::getAlgorithm(algorithm)->distance;
 }
 
+class pathInitializer : public Initializer
+{
+    Q_OBJECT
+    void initialize() const
+    {
+        QList<QString> paths = Globals->file.getList("modelSearch",QList<QString>());
+        paths.append(Globals->sdkPath + "/share/openbr/models/transforms/");
+        Globals->file.setList("modelSearch", paths);
+    }
+
+};
+BR_REGISTER(Initializer, pathInitializer)
 
 #include "core.moc"

--- a/openbr/core/core.cpp
+++ b/openbr/core/core.cpp
@@ -142,11 +142,8 @@ struct AlgorithmCore
         // assuming it is not already present.
         QFileInfo finfo(model);
         QString path = finfo.absolutePath();
-        QList<QString> paths = Globals->file.getList("modelSearch",QList<QString>() );
-        if (!paths.contains(path)) {
-            paths.append(path);
-            Globals->file.setList("modelSearch", paths);
-        }
+        if (!Globals->modelSearch.contains(path))
+            Globals->modelSearch.append(path);
 
         QtUtils::BlockCompression compressedRead;
         QFile inFile(model);
@@ -777,9 +774,7 @@ class pathInitializer : public Initializer
     Q_OBJECT
     void initialize() const
     {
-        QList<QString> paths = Globals->file.getList("modelSearch",QList<QString>());
-        paths.append(Globals->sdkPath + "/share/openbr/models/transforms/");
-        Globals->file.setList("modelSearch", paths);
+        Globals->modelSearch.append(Globals->sdkPath + "/share/openbr/models/transforms/");
     }
 
 };

--- a/openbr/openbr_plugin.h
+++ b/openbr/openbr_plugin.h
@@ -754,6 +754,12 @@ public:
     Q_PROPERTY(int crossValidate READ get_crossValidate WRITE set_crossValidate RESET reset_crossValidate)
     BR_PROPERTY(int, crossValidate, 0)
 
+    /*!
+     * \brief List of paths sub-models will be searched for on
+     */
+    Q_PROPERTY(QList<QString> modelSearch READ get_modelSearch WRITE set_modelSearch RESET reset_modelSearch)
+    BR_PROPERTY(QList<QString>, modelSearch, QList<QString>() )
+
     QHash<QString,QString> abbreviations; /*!< \brief Used by br::Transform::make() to expand abbreviated algorithms into their complete definitions. */
     QTime startTime; /*!< \brief Used to estimate timeRemaining(). */
 

--- a/openbr/plugins/core/loadstore.cpp
+++ b/openbr/plugins/core/loadstore.cpp
@@ -129,8 +129,13 @@ private:
     QString getFileName() const
     {
         if (QFileInfo(fileName).exists()) return fileName;
-        const QString file = Globals->sdkPath + "/share/openbr/models/transforms/" + fileName;
-        return QFileInfo(file).exists() ? file : QString();
+
+        foreach(const QString &path, Globals->file.getList("modelSearch",QList<QString>())) {
+            const QString file = path + "/" + fileName;
+            if (QFileInfo(file).exists())
+                return file;
+        }
+        return QString();
     }
 
     bool tryLoad()

--- a/openbr/plugins/core/loadstore.cpp
+++ b/openbr/plugins/core/loadstore.cpp
@@ -130,7 +130,7 @@ private:
     {
         if (QFileInfo(fileName).exists()) return fileName;
 
-        foreach(const QString &path, Globals->file.getList("modelSearch",QList<QString>())) {
+        foreach(const QString &path, Globals->modelSearch) {
             const QString file = path + "/" + fileName;
             if (QFileInfo(file).exists())
                 return file;


### PR DESCRIPTION
This commit is re: #344.
Consider a case where a partial model is trained, and serialized using load/store, then the complete algorithm is trained using that submodel, and saved as a complete algorithm (the output of -train):
br -algorithm "<Submodel>+OtherThings... " -train data finalModel
if the combined model is subsequently loaded, by specifying a relative or absolute path (i.e. not just loaded from the same directory), the submodel will not be found (since it is referred to in finalModel by its local name). i.e. 
br -algorithm /path/to/finalModel -enroll something
will not work.

This commit addresses that issue by also searching for sub-models in the paths were algorithms are successfully loaded from
