### PR TITLE
Better stasm inclusion/compilation

### DIFF
--- a/openbr/plugins/cmake/stasm4.cmake
+++ b/openbr/plugins/cmake/stasm4.cmake
@@ -2,14 +2,7 @@ set(BR_WITH_STASM4 ON CACHE BOOL "Build with Stasm")
 
 if(${BR_WITH_STASM4})
   find_package(Stasm4 REQUIRED)
-  set(BR_THIRDPARTY_LIBS ${BR_THIRDPARTY_LIBS} ${Stasm4_LIBS})
-
-  if(WIN32)
-    install(DIRECTORY ${Stasm_DIR}/build/ DESTINATION bin)
-  else()
-    install(DIRECTORY ${Stasm_DIR}/build/ DESTINATION lib)
-  endif()
-
+  set(BR_THIRDPARTY_SRC ${BR_THIRDPARTY_SRC} ${Stasm_SRC})
   install(DIRECTORY ${Stasm_DIR}/data/ DESTINATION share/openbr/models/stasm)
 else()
   set(BR_EXCLUDED_PLUGINS ${BR_EXCLUDED_PLUGINS} plugins/metadata/stasm4.cpp)

--- a/share/openbr/cmake/FindStasm4.cmake
+++ b/share/openbr/cmake/FindStasm4.cmake
@@ -8,13 +8,9 @@
 #   target_link_libraries(MY_TARGET ${Stasm4_LIBS})
 # ================================================================
 
-find_path(Stasm_DIR stasm/stasm_lib.h ${CMAKE_SOURCE_DIR}/3rdparty/*)
-
-add_subdirectory(${Stasm_DIR} ${Stasm_DIR}/build)
-
-set(SRC ${SOURCE};${SRC})
-
+find_path(Stasm_DIR stasm/stasm_lib.h ${CMAKE_SOURCE_DIR}/3rdparty/* NO_DEFAULT_PATH)
+mark_as_advanced(Stasm_DIR)
 include_directories(${Stasm_DIR}/stasm)
-link_directories(${Stasm_DIR}/build)
-
-set(Stasm4_LIBS stasm)
+include_directories(${Stasm_DIR}/stasm/MOD_1)
+file(GLOB Stasm_SRC "${Stasm_DIR}/stasm/*.cpp")
+file(GLOB Stasm_SRC ${Stasm_SRC} "${Stasm_DIR}/stasm/MOD_1/*.cpp")


### PR DESCRIPTION
It ended up being way easier to fix some of the long standing problems related to `stasm`.  Thus, this branch:
* Simplifies how `stasm` is built into `openbr` by just including all the source.  To some extent this was happening before but it wasn't correctly done.
* Fixes the `Stasm_DIR` issue where cmake was finding an incorrect path.
