### PR TITLE
Changed the behavior of Factory::parameters() to avoid a segfault

### DIFF
--- a/openbr/openbr_plugin.h
+++ b/openbr/openbr_plugin.h
@@ -946,7 +946,7 @@ struct Factory
     static QString parameters(const QString &name)
     {
         if (!registry) return QString();
-        T *object = make("." + name);
+        QScopedPointer<T> object(make("." + name));
         return object->parameters().join(", ");
     }
 

--- a/openbr/openbr_plugin.h
+++ b/openbr/openbr_plugin.h
@@ -946,8 +946,7 @@ struct Factory
     static QString parameters(const QString &name)
     {
         if (!registry) return QString();
-        QScopedPointer<T> object(registry->value(name)->_make());
-        object->init(name);
+        T *object = make("." + name);
         return object->parameters().join(", ");
     }
 


### PR DESCRIPTION
In the old version of ```Factory::parameters()``` passing a string with parameter arguments like ```Example(property1=value1)``` caused a segfault. This PR fixes this.