### PR TITLE
Updates to trainable distances

### DIFF
--- a/openbr/plugins/distance/fuse.cpp
+++ b/openbr/plugins/distance/fuse.cpp
@@ -29,11 +29,10 @@ namespace br
  * \author Scott Klum \cite sklum
  * \note Operation: Mean, sum, min, max are supported.
  */
-class FuseDistance : public Distance
+class FuseDistance : public ListDistance
 {
     Q_OBJECT
     Q_ENUMS(Operation)
-    Q_PROPERTY(QList<br::Distance*> distances READ get_distances WRITE set_distances RESET reset_distances)
     Q_PROPERTY(Operation operation READ get_operation WRITE set_operation RESET reset_operation STORED false)
     Q_PROPERTY(QList<float> weights READ get_weights WRITE set_weights RESET reset_weights STORED false)
 
@@ -42,17 +41,8 @@ public:
     enum Operation {Mean, Sum, Max, Min};
 
 private:
-    BR_PROPERTY(QList<br::Distance*>, distances, QList<br::Distance*>())
     BR_PROPERTY(Operation, operation, Mean)
     BR_PROPERTY(QList<float>, weights, QList<float>())
-
-    bool trainable()
-    {
-        for (int i=0; i<distances.size(); i++)
-            if (distances[i]->trainable())
-                return true;
-        return false;
-    }
 
     void train(const TemplateList &src)
     {

--- a/openbr/plugins/distance/neglogplusone.cpp
+++ b/openbr/plugins/distance/neglogplusone.cpp
@@ -24,11 +24,16 @@ namespace br
  * \brief Returns -log(distance(a,b)+1)
  * \author Josh Klontz \cite jklontz
  */
-class NegativeLogPlusOneDistance : public UntrainableDistance
+class NegativeLogPlusOneDistance : public Distance
 {
     Q_OBJECT
     Q_PROPERTY(br::Distance* distance READ get_distance WRITE set_distance RESET reset_distance STORED false)
     BR_PROPERTY(br::Distance*, distance, NULL)
+
+    bool trainable()
+    {
+        return distance->trainable();
+    }
 
     void train(const TemplateList &src)
     {

--- a/openbr/plugins/distance/pipe.cpp
+++ b/openbr/plugins/distance/pipe.cpp
@@ -30,19 +30,9 @@ namespace br
  * If the result of the comparison with any given distance is -FLOAT_MAX then this result is returned early.
  * Otherwise the returned result is the value of comparing the templates using the last br::Distance.
  */
-class PipeDistance : public Distance
+class PipeDistance : public ListDistance
 {
     Q_OBJECT
-    Q_PROPERTY(QList<br::Distance*> distances READ get_distances WRITE set_distances RESET reset_distances)
-    BR_PROPERTY(QList<br::Distance*>, distances, QList<br::Distance*>())
-
-    bool trainable()
-    {
-        for (int i=0; i<distances.size(); i++)
-            if (distances[i]->trainable())
-                return true;
-        return false;
-    }
 
     void train(const TemplateList &data)
     {

--- a/openbr/plugins/distance/pipe.cpp
+++ b/openbr/plugins/distance/pipe.cpp
@@ -36,6 +36,14 @@ class PipeDistance : public Distance
     Q_PROPERTY(QList<br::Distance*> distances READ get_distances WRITE set_distances RESET reset_distances)
     BR_PROPERTY(QList<br::Distance*>, distances, QList<br::Distance*>())
 
+    bool trainable()
+    {
+        for (int i=0; i<distances.size(); i++)
+            if (distances[i]->trainable())
+                return true;
+        return false;
+    }
+
     void train(const TemplateList &data)
     {
         QFutureSynchronizer<void> futures;

--- a/openbr/plugins/distance/sum.cpp
+++ b/openbr/plugins/distance/sum.cpp
@@ -26,19 +26,9 @@ namespace br
  * \brief Sum match scores across multiple distances
  * \author Scott Klum \cite sklum
  */
-class SumDistance : public Distance
+class SumDistance : public ListDistance
 {
     Q_OBJECT
-    Q_PROPERTY(QList<br::Distance*> distances READ get_distances WRITE set_distances RESET reset_distances)
-    BR_PROPERTY(QList<br::Distance*>, distances, QList<br::Distance*>())
-
-    bool trainable()
-    {
-        for (int i=0; i<distances.size(); i++)
-            if (distances[i]->trainable())
-                return true;
-        return false;
-    }
 
     void train(const TemplateList &data)
     {

--- a/openbr/plugins/distance/sum.cpp
+++ b/openbr/plugins/distance/sum.cpp
@@ -26,7 +26,7 @@ namespace br
  * \brief Sum match scores across multiple distances
  * \author Scott Klum \cite sklum
  */
-class SumDistance : public UntrainableDistance
+class SumDistance : public Distance
 {
     Q_OBJECT
     Q_PROPERTY(QList<br::Distance*> distances READ get_distances WRITE set_distances RESET reset_distances)

--- a/openbr/plugins/distance/sum.cpp
+++ b/openbr/plugins/distance/sum.cpp
@@ -32,6 +32,14 @@ class SumDistance : public UntrainableDistance
     Q_PROPERTY(QList<br::Distance*> distances READ get_distances WRITE set_distances RESET reset_distances)
     BR_PROPERTY(QList<br::Distance*>, distances, QList<br::Distance*>())
 
+    bool trainable()
+    {
+        for (int i=0; i<distances.size(); i++)
+            if (distances[i]->trainable())
+                return true;
+        return false;
+    }
+
     void train(const TemplateList &data)
     {
         QFutureSynchronizer<void> futures;

--- a/openbr/plugins/openbr_internal.h
+++ b/openbr/plugins/openbr_internal.h
@@ -486,7 +486,7 @@ private:
 };
 
 /*!
- * \brief A br::Distance that does not require training data.
+ * \brief A br::Distance that checks the elements of its list property to see if it needs to be trained.
  */
 class BR_EXPORT ListDistance : public Distance
 {

--- a/openbr/plugins/openbr_internal.h
+++ b/openbr/plugins/openbr_internal.h
@@ -485,6 +485,26 @@ private:
     void train(const TemplateList &data) { (void) data; }
 };
 
+/*!
+ * \brief A br::Distance that does not require training data.
+ */
+class BR_EXPORT ListDistance : public Distance
+{
+    Q_OBJECT
+
+public:
+    Q_PROPERTY(QList<br::Distance*> distances READ get_distances WRITE set_distances RESET reset_distances)
+    BR_PROPERTY(QList<br::Distance*>, distances, QList<br::Distance*>())
+
+    bool trainable()
+    {
+        for (int i=0; i<distances.size(); i++)
+            if (distances[i]->trainable())
+                return true;
+        return false;
+    }
+};
+
 }
 
 #endif // OPENBR_INTERNAL_H


### PR DESCRIPTION
This branch adds some optimizations in `Distance`s with one or more child `Distance`s such that if none of the child distances are trainable, the distance returns `false` for its `trainable` method skipping the need to project enrollment during training.  There is also some related cleanup of `FuseDistance`.