### PR TITLE
FTE in File::append

### DIFF
--- a/openbr/openbr_plugin.cpp
+++ b/openbr/openbr_plugin.cpp
@@ -97,6 +97,7 @@ void File::append(const File &other)
         }
     }
     append(other.m_metadata);
+    fte = fte | other.fte;
 }
 
 QList<File> File::split() const


### PR DESCRIPTION
In an algorithm string along the lines of `Transform1+Transform2/Transform3+Transform4`, if either `Transform2` or `Transform3` sets the `fte` flag, it will not be present in the `Template`s passed to `Transform4` because of the logic in the various `Fork::project` calls.  This is because the `Template`s passed through a given child `Transform` of fork are merged with the original file and nothing handles the `fte` flag in these functions.  This branch changes that.