### PR TITLE
Not storing cv::Mat metadata when fte

### DIFF
--- a/openbr/plugins/gallery/binary.cpp
+++ b/openbr/plugins/gallery/binary.cpp
@@ -178,10 +178,13 @@ class galGallery : public BinaryGallery
         else if (t.file.fte) {
              // Only write metadata for failure to enroll, but remove any stored QVariants of type cv::Mat
             File f = t.file;
-            QList<QVariant> values = f.localMetadata().values();
-            for (int i=0; i<values.size(); i++)
-                if (strcmp(values[i].typeName(),"cv::Mat") == 0)
-                    f.remove(f.localMetadata().key(values[i]));
+            QVariantMap metadata = f.localMetadata();
+            QMapIterator<QString, QVariant> i(metadata);
+            while (i.hasNext()) {
+                i.next();
+                if (strcmp(i.value().typeName(),"cv::Mat") == 0)
+                    f.remove(i.key());
+            }
             stream << Template(f);
         }
         else

--- a/openbr/plugins/gallery/binary.cpp
+++ b/openbr/plugins/gallery/binary.cpp
@@ -175,8 +175,15 @@ class galGallery : public BinaryGallery
     {
         if (t.isEmpty() && t.file.isNull())
             return;
-        else if (t.file.fte)
-            stream << Template(t.file); // only write metadata for failure to enroll
+        else if (t.file.fte) {
+             // Only write metadata for failure to enroll, but remove any stored QVariants of type cv::Mat
+            File f = t.file;
+            QList<QVariant> values = f.localMetadata().values();
+            for (int i=0; i<values.size(); i++)
+                if (strcmp(values[i].typeName(),"cv::Mat") == 0)
+                    f.remove(f.localMetadata().key(values[i]));
+            stream << Template(f);
+        }
         else
             stream << t;
     }


### PR DESCRIPTION
@caotto @jklontz per our earlier convo.  My expectation is that the algorithm string should be able to handle removal of specific metadata in the case of successful enrollment.  This change constitutes a catch-all in the case of an `fte`.