### PR TITLE
Random test/train split in TemplateList::Partition

### DIFF
--- a/app/br/br.cpp
+++ b/app/br/br.cpp
@@ -69,6 +69,7 @@ public:
 
         bool daemon = false;
         const char *daemon_pipe = NULL;
+        bool isInt = false;
         while (daemon || (argc > 0)) {
             const char *fun;
             int parc;
@@ -78,7 +79,12 @@ public:
 
             fun = argv[0];
             if (fun[0] == '-') fun++;
-            parc = 0; while ((parc+1 < argc) && (argv[parc+1][0] != '-')) parc++;
+            parc = 0;
+            QString(argv[parc+1]).toInt(&isInt);
+            while ((parc+1 < argc) && ((argv[parc+1][0] != '-') || isInt)) {
+                parc++;
+                QString(argv[parc+1]).toInt(&isInt);
+            }
             parv = (const char **)&argv[1];
             argc = argc - (parc+1);
             argv = &argv[parc+1];

--- a/openbr/core/bee.cpp
+++ b/openbr/core/bee.cpp
@@ -230,7 +230,7 @@ void makeMask(const QString &targetInput, const QString &queryInput, const QStri
     const FileList targets = TemplateList::fromGallery(targetInput).files();
     const FileList queries = (queryInput == ".") ? targets : TemplateList::fromGallery(queryInput).files();
     const int partitions = targets.first().get<int>("crossValidate");
-    if (partitions == 0) {
+    if (partitions <= 0) {
         writeMatrix(makeMask(targets, queries), mask, targetInput, queryInput);
     } else {
         if (!mask.contains("%1")) qFatal("Mask file name missing partition number place marker (%%1)");
@@ -246,7 +246,7 @@ void makePairwiseMask(const QString &targetInput, const QString &queryInput, con
     const FileList targets = TemplateList::fromGallery(targetInput).files();
     const FileList queries = (queryInput == ".") ? targets : TemplateList::fromGallery(queryInput).files();
     const int partitions = targets.first().get<int>("crossValidate");
-    if (partitions == 0) {
+    if (partitions <= 0) {
         writeMatrix(makePairwiseMask(targets, queries), mask, targetInput, queryInput);
     } else {
         if (!mask.contains("%1")) qFatal("Mask file name missing partition number place marker (%%1)");

--- a/openbr/core/core.cpp
+++ b/openbr/core/core.cpp
@@ -69,7 +69,7 @@ struct AlgorithmCore
         QScopedPointer<Transform> trainingWrapper(br::wrapTransform(transform.data(), "Stream(readMode=DistributeFrames)"));
         TemplateList data(TemplateList::fromGallery(input));
 
-        if (Globals->crossValidate > 1)
+        if (abs(Globals->crossValidate) > 1)
             for (int i=data.size()-1; i>=0; i--)
                 if (data[i].file.get<bool>("allPartitions",false) || data[i].file.get<bool>("duplicatePartitions",false))
                     data.removeAt(i);

--- a/openbr/openbr_plugin.cpp
+++ b/openbr/openbr_plugin.cpp
@@ -434,7 +434,7 @@ TemplateList TemplateList::fromGallery(const br::File &gallery)
         if (gallery.getBool("reduce"))
             newTemplates = newTemplates.reduced();
 
-        if (Globals->crossValidate > 1)
+        if (abs(Globals->crossValidate) > 1)
             newTemplates = newTemplates.partition("Label");
 
         if (!templates.isEmpty() && gallery.get<bool>("merge", false)) {

--- a/openbr/openbr_plugin.cpp
+++ b/openbr/openbr_plugin.cpp
@@ -529,7 +529,7 @@ QList<int> TemplateList::applyIndex(const QString &propName, const QHash<QString
     return result;
 }
 
-TemplateList TemplateList::partition(const QString &inputVariable, int bootStrap) const
+TemplateList TemplateList::partition(const QString &inputVariable, unsigned int bootStrap) const
 {
     TemplateList partitioned = *this;
     if (bootStrap > 0) {

--- a/openbr/openbr_plugin.h
+++ b/openbr/openbr_plugin.h
@@ -459,7 +459,7 @@ struct TemplateList : public QList<Template>
     BR_EXPORT static TemplateList relabel(const TemplateList &tl, const QString &propName, bool preserveIntegers);
 
     /*!< \brief Assign templates to folds partitions. */
-    BR_EXPORT TemplateList partition(const QString &inputVariable, int bootStrap = 0) const;
+    BR_EXPORT TemplateList partition(const QString &inputVariable, unsigned int bootStrap = 0) const;
 
     BR_EXPORT QList<int> indexProperty(const QString &propName, QHash<QString, int> * valueMap=NULL,QHash<int, QVariant> * reverseLookup = NULL) const;
     BR_EXPORT QList<int> indexProperty(const QString &propName, QHash<QString, int> &valueMap, QHash<int, QVariant> &reverseLookup) const;

--- a/openbr/openbr_plugin.h
+++ b/openbr/openbr_plugin.h
@@ -459,7 +459,7 @@ struct TemplateList : public QList<Template>
     BR_EXPORT static TemplateList relabel(const TemplateList &tl, const QString &propName, bool preserveIntegers);
 
     /*!< \brief Assign templates to folds partitions. */
-    BR_EXPORT TemplateList partition(const QString &inputVariable, unsigned int bootStrap = 0) const;
+    BR_EXPORT TemplateList partition(const QString &inputVariable, unsigned int randomSeed = 0) const;
 
     BR_EXPORT QList<int> indexProperty(const QString &propName, QHash<QString, int> * valueMap=NULL,QHash<int, QVariant> * reverseLookup = NULL) const;
     BR_EXPORT QList<int> indexProperty(const QString &propName, QHash<QString, int> &valueMap, QHash<int, QVariant> &reverseLookup) const;

--- a/openbr/openbr_plugin.h
+++ b/openbr/openbr_plugin.h
@@ -459,7 +459,7 @@ struct TemplateList : public QList<Template>
     BR_EXPORT static TemplateList relabel(const TemplateList &tl, const QString &propName, bool preserveIntegers);
 
     /*!< \brief Assign templates to folds partitions. */
-    BR_EXPORT TemplateList partition(const QString &inputVariable) const;
+    BR_EXPORT TemplateList partition(const QString &inputVariable, int bootStrap = 0) const;
 
     BR_EXPORT QList<int> indexProperty(const QString &propName, QHash<QString, int> * valueMap=NULL,QHash<int, QVariant> * reverseLookup = NULL) const;
     BR_EXPORT QList<int> indexProperty(const QString &propName, QHash<QString, int> &valueMap, QHash<int, QVariant> &reverseLookup) const;

--- a/openbr/plugins/core/crossvalidate.cpp
+++ b/openbr/plugins/core/crossvalidate.cpp
@@ -56,10 +56,10 @@ class CrossValidateTransform : public MetaTransform
     Q_OBJECT
     Q_PROPERTY(QString description READ get_description WRITE set_description RESET reset_description STORED false)
     Q_PROPERTY(QString inputVariable READ get_inputVariable WRITE set_inputVariable RESET reset_inputVariable STORED false)
-    Q_PROPERTY(int bootStrap READ get_bootStrap WRITE set_bootStrap RESET reset_bootStrap STORED false)
+    Q_PROPERTY(unsigned int bootStrap READ get_bootStrap WRITE set_bootStrap RESET reset_bootStrap STORED false)
     BR_PROPERTY(QString, description, "Identity")
     BR_PROPERTY(QString, inputVariable, "Label")
-    BR_PROPERTY(int, bootStrap, 0)
+    BR_PROPERTY(unsigned int, bootStrap, 0)
 
     // numPartitions copies of transform specified by description.
     QList<br::Transform*> transforms;
@@ -74,7 +74,7 @@ class CrossValidateTransform : public MetaTransform
         while (transforms.size() < numPartitions)
             transforms.append(make(description));
 
-        if (numPartitions < 2 && !(bootStrap > 0)) {
+        if (numPartitions < 2 && !bootStrap) {
             transforms.first()->train(data);
             return;
         }

--- a/openbr/plugins/output/eval.cpp
+++ b/openbr/plugins/output/eval.cpp
@@ -45,7 +45,7 @@ class evalOutput : public MatrixOutput
 
         if (data.data) {
             const QString csv = QString(file.name).replace(".eval", ".csv");
-            if ((Globals->crossValidate == 0) || (!crossValidate)) {
+            if ((Globals->crossValidate <= 0) || (!crossValidate)) {
                 Evaluate(data, targetFiles, queryFiles, csv);
             } else {
                 QFutureSynchronizer<float> futures;


### PR DESCRIPTION
This PR allows the user to specify a `bootStrap` seed to randomly split a dataset into training/testing sets based on a partition `inputVariable`.  

This could be used as a quick one-off with a seed of your choosing, or possibly over a set of numbers, say (1..10) within a script, for example:
```
for i in {1..10}
do
  br -crossValidate 1 -algorithm "CrossValidate(description=$ALG,bootStrap=${i}):CrossValidate+Dist" -train target.xml query.xml model
  br -crossValidate 1 -algorithm model -enroll target.xml target.gal
  br -crossValidate 1 -algorithm model -enroll query.xml query.gal
  br -crossValidate 1 -algorithm model -compare target.gal query.gal results%1.eval
  mv results0.csv Algorithm_Split/results_${i}.csv
done
br -plot Algorithm_Split/* results.pdf[smooth=Split]
```
This is useful for datasets where the testing size becomes prohibitively small as n increases in n-fold cross-validation.  

@sklum please review, @bklare fyi