### PR TITLE
Support file in memory buffer

### DIFF
--- a/openbr/openbr_plugin.cpp
+++ b/openbr/openbr_plugin.cpp
@@ -59,6 +59,8 @@ static const QMetaObject *getInterface(const QObject *obj)
 // Note that the convention for displaying metadata is as follows:
 // [] for lists in which argument order does not matter (e.g. [FTO=false, Index=0]),
 // () for lists in which argument order matters (e.g. First_Eye(100.0,100.0)).
+QMap<QString,std::vector<char> > File::MemoryFile;
+
 QString File::flat() const
 {
     QStringList values;

--- a/openbr/openbr_plugin.h
+++ b/openbr/openbr_plugin.h
@@ -326,6 +326,7 @@ struct BR_EXPORT File
     inline void setRects(const QList<cv::Rect> &rects) { clearRects(); appendRects(rects); } /*!< \brief Overwrites the file's rect list. */
 
     bool fte;
+    static QMap<QString,std::vector<char> > MemoryFile;
 private:
     QVariantMap m_metadata;
     BR_EXPORT friend QDataStream &operator<<(QDataStream &stream, const File &file);

--- a/openbr/plugins/format.cpp
+++ b/openbr/plugins/format.cpp
@@ -221,6 +221,13 @@ class DefaultFormat : public Format
     {
         Template t;
 
+        if ( file.name.startsWith("memory:") )
+        {
+            std::vector<char> memoryimage = file.MemoryFile.value(file.name);
+            Mat m = imdecode(memoryimage,1);
+            t.append(m);
+        }
+        else
         if (file.name.startsWith("http://") || file.name.startsWith("https://") || file.name.startsWith("www.")) {
             if (Factory<Format>::names().contains("url")) {
                 File urlFile = file;


### PR DESCRIPTION
We can query and transform files in memory buffer by this patch:

QString path("memory:xxx123xxx");
std::vector<char> v;
v.insert(v.end(),buffer,buffer+bufferlen);
br::File::MemoryFile.insert(path,v);

br::Template query(path);
br::TemplateList queries;
queries.append(query);

queries >> *transform;
...
br::File::MemoryFile.remove(path);