### PR TITLE
Serialize algorithm

### DIFF
--- a/openbr/core/opencvutils.cpp
+++ b/openbr/core/opencvutils.cpp
@@ -280,6 +280,24 @@ void OpenCVUtils::storeModel(const CvStatModel &model, QDataStream &stream)
     stream << data;
 }
 
+void OpenCVUtils::storeModel(const cv::Algorithm &model, QDataStream &stream)
+{
+    // Create local file
+    QTemporaryFile tempFile;
+    tempFile.open();
+    tempFile.close();
+
+    // Save MLP to local file
+    cv::FileStorage fs(tempFile.fileName().toStdString(), cv::FileStorage::WRITE);
+    model.write(fs);
+
+    // Copy local file contents to stream
+    tempFile.open();
+    QByteArray data = tempFile.readAll();
+    tempFile.close();
+    stream << data;
+}
+
 void OpenCVUtils::loadModel(CvStatModel &model, QDataStream &stream)
 {
     // Copy local file contents from stream
@@ -294,6 +312,23 @@ void OpenCVUtils::loadModel(CvStatModel &model, QDataStream &stream)
 
     // Load MLP from local file
     model.load(qPrintable(tempFile.fileName()));
+}
+
+void OpenCVUtils::loadModel(cv::Algorithm &model, QDataStream &stream)
+{
+    // Copy local file contents from stream
+    QByteArray data;
+    stream >> data;
+
+    // Create local file
+    QTemporaryFile tempFile(QDir::tempPath()+"/model");
+    tempFile.open();
+    tempFile.write(data);
+    tempFile.close();
+
+    // Load MLP from local file
+    cv::FileStorage fs(tempFile.fileName().toStdString(), cv::FileStorage::READ);
+    model.read(fs["em"]);
 }
 
 Point2f OpenCVUtils::toPoint(const QPointF &qPoint)

--- a/openbr/core/opencvutils.cpp
+++ b/openbr/core/opencvutils.cpp
@@ -290,6 +290,7 @@ void OpenCVUtils::storeModel(const cv::Algorithm &model, QDataStream &stream)
     // Save MLP to local file
     cv::FileStorage fs(tempFile.fileName().toStdString(), cv::FileStorage::WRITE);
     model.write(fs);
+    fs.release();
 
     // Copy local file contents to stream
     tempFile.open();
@@ -328,7 +329,7 @@ void OpenCVUtils::loadModel(cv::Algorithm &model, QDataStream &stream)
 
     // Load MLP from local file
     cv::FileStorage fs(tempFile.fileName().toStdString(), cv::FileStorage::READ);
-    model.read(fs["em"]);
+    model.read(fs[""]);
 }
 
 Point2f OpenCVUtils::toPoint(const QPointF &qPoint)

--- a/openbr/core/opencvutils.h
+++ b/openbr/core/opencvutils.h
@@ -52,7 +52,9 @@ namespace OpenCVUtils
 
     // Model storage
     void storeModel(const CvStatModel &model, QDataStream &stream);
+    void storeModel(const cv::Algorithm &model, QDataStream &stream);
     void loadModel(CvStatModel &model, QDataStream &stream);
+    void loadModel(cv::Algorithm &model, QDataStream &stream);
 
     template <typename T>
     T getElement(const cv::Mat &m, int r, int c)


### PR DESCRIPTION
Allows the serialization of OpenCV objects that derive from the Algorithm object. Currently only the CvStatModel is supported. 