### PR TITLE
Network

### DIFF
--- a/app/br/br.cpp
+++ b/app/br/br.cpp
@@ -217,10 +217,10 @@ public:
             } else if (!strcmp(fun, "slave")) {
                 #ifdef BR_WITH_QTNETWORK
                 check(parc == 1, "Incorrect parameter count for 'slave'");
-		br_slave_process(parv[0]);
-		#else
-		qFatal("Build with QtNetwork to use the slave option");
-		#endif
+                br_slave_process(parv[0]);
+                #else
+                qFatal("Build with QtNetwork to use the slave option");
+                #endif
             } else if (!strcmp(fun, "exit")) {
                 check(parc == 0, "No parameters expected for 'exit'.");
                 daemon = false;

--- a/app/br/br.cpp
+++ b/app/br/br.cpp
@@ -215,8 +215,12 @@ public:
                 daemon = true;
                 daemon_pipe = parv[0];
             } else if (!strcmp(fun, "slave")) {
+                #ifdef BR_WITH_QTNETWORK
                 check(parc == 1, "Incorrect parameter count for 'slave'");
-                br_slave_process(parv[0]);
+		br_slave_process(parv[0]);
+		#else
+		qFatal("Build with QtNetwork to use the slave option");
+		#endif
             } else if (!strcmp(fun, "exit")) {
                 check(parc == 0, "No parameters expected for 'exit'.");
                 daemon = false;

--- a/openbr/openbr.cpp
+++ b/openbr/openbr.cpp
@@ -303,6 +303,7 @@ const char *br_version()
     return version.data();
 }
 
+#ifdef BR_WITH_QTNETWORK 
 void br_slave_process(const char *baseName)
 {
     WorkerProcess *worker = new WorkerProcess;
@@ -311,6 +312,7 @@ void br_slave_process(const char *baseName)
     worker->mainLoop();
     delete worker;
 }
+#endif
 
 br_template br_load_img(const char *data, int len)
 {

--- a/openbr/openbr_plugin.cpp
+++ b/openbr/openbr_plugin.cpp
@@ -19,7 +19,6 @@
 #include <QFutureSynchronizer>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QLocalSocket>
 #include <QMetaProperty>
 #include <qnumeric.h>
 #include <QPointF>
@@ -34,7 +33,12 @@
 
 #ifndef BR_EMBEDDED
 #include <QApplication>
-#endif
+#endif // BR_EMBEDDED
+
+#ifdef BR_WITH_QTNETWORK
+#include <QLocalSocket>
+Q_DECLARE_METATYPE(QLocalSocket::LocalSocketState)
+#endif // BR_WITH_QTNETWORK
 
 #include "openbr_plugin.h"
 #include "version.h"
@@ -46,8 +50,6 @@
 
 using namespace br;
 using namespace cv;
-
-Q_DECLARE_METATYPE(QLocalSocket::LocalSocketState)
 
 static const QMetaObject *getInterface(const QObject *obj)
 {
@@ -1277,8 +1279,11 @@ void br::Context::initialize(int &argc, char *argv[], QString sdkPath, bool useG
     qRegisterMetaType< QList<br::Distance*> >();
     qRegisterMetaType< QList<br::Representation* > >();
     qRegisterMetaType< QList<br::Classifier* > >();
+    
+#ifdef BR_WITH_QTNETWORK
     qRegisterMetaType< QAbstractSocket::SocketState> ();
     qRegisterMetaType< QLocalSocket::LocalSocketState> ();
+#endif // BR_WITH_QTNETWORK
 
     Globals = new Context();
     Globals->init(File());

--- a/openbr/plugins/cmake/network.cmake
+++ b/openbr/plugins/cmake/network.cmake
@@ -1,4 +1,9 @@
 set(BR_WITH_QTNETWORK ON CACHE BOOL "Build with QtNetwork")
+
+if (${BR_EMBEDDED})
+  set(BR_WITH_QTNETWORK OFF)
+endif()
+
 if(${BR_WITH_QTNETWORK})
   find_package(Qt5Network)
   find_package(HttpParser)
@@ -9,4 +14,7 @@ else()
   set(BR_EXCLUDED_PLUGINS ${BR_EXCLUDED_PLUGINS} plugins/format/url.cpp)
   set(BR_EXCLUDED_PLUGINS ${BR_EXCLUDED_PLUGINS} plugins/format/post.cpp)
   set(BR_EXCLUDED_PLUGINS ${BR_EXCLUDED_PLUGINS} plugins/gallery/post.cpp)
+  set(BR_EXCLUDED_PLUGINS ${BR_EXCLUDED_PLUGINS} plugins/gallery/google.cpp)
+  set(BR_EXCLUDED_PLUGINS ${BR_EXCLUDED_PLUGINS} plugins/io/download.cpp)
+  set(BR_EXCLUDED_PLUGINS ${BR_EXCLUDED_PLUGINS} plugins/core/processwrapper.cpp)
 endif()

--- a/openbr/plugins/cmake/network.cmake
+++ b/openbr/plugins/cmake/network.cmake
@@ -1,4 +1,5 @@
 set(BR_WITH_QTNETWORK ON CACHE BOOL "Build with QtNetwork")
+add_definitions(-DBR_WITH_QTNETWORK)
 
 if (${BR_EMBEDDED})
   set(BR_WITH_QTNETWORK OFF)

--- a/openbr/plugins/openbr_internal.h
+++ b/openbr/plugins/openbr_internal.h
@@ -366,6 +366,7 @@ protected:
     CompositeTransform() : TimeVaryingTransform(false) {}
 };
 
+#ifdef BR_WITH_QTNETWORK
 class EnrollmentWorker;
 
 // Implemented in plugins/process.cpp
@@ -377,6 +378,7 @@ struct WorkerProcess
 
     void mainLoop();
 };
+#endif
 
 class MetadataTransform : public Transform
 {


### PR DESCRIPTION
Even if one builds with `BR_EMBEDDED`, OpenBR still depends on the `QtNetwork` library.  This branch fixes that.  @jklontz?