### PR TITLE
Fixed invalid R install packages in API docs

### DIFF
--- a/docs/docs/api_docs/c_api/functions.md
+++ b/docs/docs/api_docs/c_api/functions.md
@@ -645,7 +645,7 @@ The example below plots plots the six br_eval results in the Algorithm_Dataset f
 
 This function requires a current [R][R] installation with the following packages:
 
-        install.packages(c("ggplot2", "gplots", "reshape", "scales", "jpg", "png"))
+        install.packages(c("ggplot2", "gplots", "reshape", "scales", "jpeg", "png"))
 
 * **function definiton:**
 
@@ -684,7 +684,7 @@ When computing *continuous* curves, true positives and false negatives are measu
 
 This function requires a current [R](http://www.r-project.org/) installation with the following packages:
 
-    install.packages(c("ggplot2", "gplots", "reshape", "scales", "jpg", "png"))
+    install.packages(c("ggplot2", "gplots", "reshape", "scales", "jpeg", "png"))
 
 * **function definition:**
 


### PR DESCRIPTION
`br` instructs user to check API documentation for list of dependent packages.  One of the listed packages is `jpg` which doesn't exist in any R package repo.  Attempted to install `jpeg` package and plotting (i.e. `br -plot Eigenfaces.csv Eigenfaces.pdf`) works as expected.

Briefly looked through the rest of the API specs and it appears that these are all the references.