### PR TITLE
Commented unnecessary qDebug msg

### DIFF
--- a/openbr/plugins/core/expand.cpp
+++ b/openbr/plugins/core/expand.cpp
@@ -64,7 +64,7 @@ class ExpandTransform : public UntrainableMetaTransform
     virtual void project(const Template &src, Template &dst) const
     {
         dst = src;
-        qDebug("Called Expand project(Template,Template), nothing will happen");
+        //qDebug("Called Expand project(Template,Template), nothing will happen");
     }
 };
 


### PR DESCRIPTION
This message is not at all helpful and is very tricky to get rid of via CMake.
The message is spamming stdout unnecessarily.