### PR TITLE
fix compile error with dlib

### DIFF
--- a/openbr/plugins/classification/dlib.cpp
+++ b/openbr/plugins/classification/dlib.cpp
@@ -1,5 +1,5 @@
 #include <opencv2/imgproc/imgproc.hpp>
-#include <dlib/image_processing/frontal_face_detector.h>
+#include <dlib/image_processing.h>
 #include <dlib/opencv.h>
 
 #include "openbr/plugins/openbr_internal.h"


### PR DESCRIPTION
Hey guys,

just a short fix to make your awesome framework compile with dlib again (shape_predictor was missing).

Thanks and Cheers
Martin