### PR TITLE
Fix multiprocess support

### DIFF
--- a/app/br/br.cpp
+++ b/app/br/br.cpp
@@ -223,6 +223,9 @@ public:
                 check(parc == 1, "Incorrect parameter count for 'daemon'.");
                 daemon = true;
                 daemon_pipe = parv[0];
+            } else if (!strcmp(fun, "slave")) {
+                check(parc == 1, "Incorrect parameter count for 'slave'");
+                br_slave_process(parv[0]);
             } else if (!strcmp(fun, "exit")) {
                 check(parc == 0, "No parameters expected for 'exit'.");
                 daemon = false;

--- a/app/br/br.cpp
+++ b/app/br/br.cpp
@@ -224,6 +224,8 @@ public:
                 daemon = true;
                 daemon_pipe = parv[0];
             } else if (!strcmp(fun, "slave")) {
+                // This is used internally by processWrapper, if you want to remove it, also remove
+                // plugins/core/processwrapper.cpp
                 check(parc == 1, "Incorrect parameter count for 'slave'");
                 br_slave_process(parv[0]);
             } else if (!strcmp(fun, "exit")) {

--- a/openbr/openbr.cpp
+++ b/openbr/openbr.cpp
@@ -318,7 +318,7 @@ const char *br_version()
 
 void br_slave_process(const char *baseName)
 {
-#ifndef BR_EMBEDDED
+#ifdef BR_WITH_QTNETWORK
     WorkerProcess *worker = new WorkerProcess;
     worker->transform = Globals->algorithm;
     worker->baseName = baseName;
@@ -326,7 +326,7 @@ void br_slave_process(const char *baseName)
     delete worker;
 #else
     (void) baseName;
-    qFatal("br_slave_process not supported in embedded builds!");
+    qFatal("multiprocess support requires building with QtNetwork enabled (set BR_WITH_QTNETWORK in cmake).");
 #endif
 }
 

--- a/openbr/openbr.cpp
+++ b/openbr/openbr.cpp
@@ -316,6 +316,20 @@ const char *br_version()
     return version.data();
 }
 
+void br_slave_process(const char *baseName)
+{
+#ifndef BR_EMBEDDED
+    WorkerProcess *worker = new WorkerProcess;
+    worker->transform = Globals->algorithm;
+    worker->baseName = baseName;
+    worker->mainLoop();
+    delete worker;
+#else
+    (void) baseName;
+    qFatal("br_slave_process not supported in embedded builds!");
+#endif
+}
+
 br_template br_load_img(const char *data, int len)
 {
     std::vector<char> buf(data, data+len);

--- a/openbr/openbr.h
+++ b/openbr/openbr.h
@@ -117,6 +117,8 @@ BR_EXPORT void br_train_n(int num_inputs, const char *inputs[], const char *mode
 
 BR_EXPORT const char *br_version();
 
+BR_EXPORT void br_slave_process(const char * baseKey);
+
 BR_EXPORT void br_likely(const char *input_type, const char *output_type, const char *output_source_file);
 
 // to avoid having to include unwanted headers

--- a/openbr/plugins/cmake/network.cmake
+++ b/openbr/plugins/cmake/network.cmake
@@ -7,6 +7,7 @@ if(${BR_WITH_QTNETWORK})
   if(${BR_INSTALL_SHARE})
     install(FILES ${HTTPPARSER_LICENSE} RENAME http-parser DESTINATION share/openbr/licenses)
   endif()
+  add_definitions(-DBR_WITH_QTNETWORK)
 else()
   set(BR_EXCLUDED_PLUGINS ${BR_EXCLUDED_PLUGINS} plugins/core/processwrapper.cpp
                                                  plugins/io/download.cpp

--- a/openbr/plugins/cmake/network.cmake
+++ b/openbr/plugins/cmake/network.cmake
@@ -1,4 +1,4 @@
-option(BR_WITH_QTNETWORK "Build with QtNetwork" ON)
+option(BR_WITH_QTNETWORK "Build with QtNetwork" OFF)
 if(${BR_WITH_QTNETWORK})
   find_package(Qt5Network)
   find_package(HttpParser)

--- a/openbr/plugins/cmake/network.cmake
+++ b/openbr/plugins/cmake/network.cmake
@@ -1,4 +1,4 @@
-option(BR_WITH_QTNETWORK "Build with QtNetwork" OFF)
+option(BR_WITH_QTNETWORK "Build with QtNetwork" ON)
 if(${BR_WITH_QTNETWORK})
   find_package(Qt5Network)
   find_package(HttpParser)


### PR DESCRIPTION
Per discussion in 
https://github.com/biometrics/openbr/commit/56b776899118a15aaaf85810d53f15c1a2de3fcc
multiprocess support was broken by the removal of br_slave_process, and there was no deep reason why this was necessary.
This branch re-introduces it, but only enables it when BR_WITH_QTNETWORK is on, so using qtnetwork can remain off by default. 

@jklontz, @sklum  care to review? 

