### PR TITLE
Possible fix for run-time crash when using qt 5.7

### DIFF
--- a/openbr/openbr_plugin.cpp
+++ b/openbr/openbr_plugin.cpp
@@ -1617,7 +1617,7 @@ Transform *Transform::make(QString str, QObject *parent)
 
     if (transform->independent) {
         File independent(".Independent");
-        independent.set("transform", qVariantFromValue<void*>(transform));
+        independent.set("transform", QVariant::fromValue(transform));
         transform = Factory<Transform>::make(independent);
     }
 


### PR DESCRIPTION
Possible fix for runtime crash when using qt 5.7.  Without this fix -- crash happens because QObject::setProperty(qPrintable(name), value) returns false within Object::setProperty