### PR TITLE
Adjust enroll append behavior

### DIFF
--- a/openbr/core/core.cpp
+++ b/openbr/core/core.cpp
@@ -209,8 +209,12 @@ struct AlgorithmCore
         stages.append(enroll);
 
         QString outputDesc;
-        if (fileExclusion)
-            outputDesc = "FileExclusion(" + gallery.flat() + ")+";
+        QScopedPointer<Transform> exclusionBase;
+        if (fileExclusion) {
+            exclusionBase.reset(Transform::make("FileExclusion(" + gallery.flat() + ")", NULL));
+            stages.prepend(exclusionBase.data());
+        }
+
         if (!noOutput)
             outputDesc.append("GalleryOutput("+gallery.flat()+")+");
 


### PR DESCRIPTION
per discussion in #488, adjust behavior of "append" flat during enrollment to exclude files at the beginning rather than end of processing

@sklum care to review? This appears to work for me based on some brief testing on MEDS data, but you should check for your usecase.
