### PR TITLE
Changes to evalEER

### DIFF
--- a/app/br/br.cpp
+++ b/app/br/br.cpp
@@ -192,6 +192,9 @@ public:
             } else if (!strcmp(fun, "plotKNN")) {
                 check(parc >=2, "Incorrect parameter count for 'plotKNN'.");
                 br_plot_knn(parc-1, parv, parv[parc-1], true);
+            } else if (!strcmp(fun, "plotEER")) {
+                check(parc >= 2, "Incorrect parameter count for 'plotEER'.");
+                br_plot_eer(parc-1, parv, parv[parc-1], true);
             } else if (!strcmp(fun, "project")) {
                 check(parc == 2, "Insufficient parameter count for 'project'.");
                 br_project(parv[0], parv[1]);
@@ -298,6 +301,7 @@ private:
                "-plotLandmarking <file> ... <file> {destination}\n"
                "-plotMetadata <file> ... <file> <columns>\n"
                "-plotKNN <file> ... <file> {destination}\n"
+               "-plotEER <file> ... <file> {destination}\n"
                "-project <input_gallery> {output_gallery}\n"
                "-deduplicate <input_gallery> <output_gallery> <threshold>\n"
                "-likely <input_type> <output_type> <output_likely_source>\n"

--- a/openbr/core/eval.h
+++ b/openbr/core/eval.h
@@ -34,7 +34,7 @@ namespace br
     float EvalLandmarking(const QString &predictedGallery, const QString &truthGallery, const QString &csv = "", int normalizationIndexA = 0, int normalizationIndexB = 1, int sampleIndex = 0, int totalExamples = 5); // Return average error
     void EvalRegression(const QString &predictedGallery, const QString &truthGallery, QString predictedProperty = "", QString truthProperty = "");
     void EvalKNN(const QString &knnGraph, const QString &knnTruth, const QString &csv = "");
-    void EvalEER(const QString &predictedXML, const QString gt_property = "", const QString distribution_property = "", const QString &pdf = "");
+    void EvalEER(const QString &predictedXML, const QString gt_property = "", const QString distribution_property = "", const QString &csv = "");
     struct Candidate
     {
         size_t index;

--- a/openbr/core/plot.h
+++ b/openbr/core/plot.h
@@ -29,6 +29,7 @@ namespace br
     bool PlotLandmarking(const QStringList &files, const File &destination, bool show = false);
     bool PlotMetadata(const QStringList &files, const QString &destination, bool show = false);
     bool PlotKNN(const QStringList &files, const File &destination, bool show = false);
+    bool PlotEER(const QStringList &files, const File &destination, bool show = false);
 }
 
 #endif // BR_PLOT_H

--- a/openbr/openbr.cpp
+++ b/openbr/openbr.cpp
@@ -227,6 +227,11 @@ bool br_plot_knn(int num_files, const char *files[], const char *destination, bo
     return PlotKNN(QtUtils::toStringList(num_files, files), destination, show);
 }
 
+bool br_plot_eer(int num_files, const char *files[], const char *destination, bool show)
+{
+    return PlotEER(QtUtils::toStringList(num_files, files), destination, show);
+}
+
 float br_progress()
 {
     return Globals->progress();

--- a/openbr/openbr.h
+++ b/openbr/openbr.h
@@ -97,6 +97,8 @@ BR_EXPORT bool br_plot_metadata(int num_files, const char *files[], const char *
 
 BR_EXPORT bool br_plot_knn(int num_files, const char *files[], const char *destination, bool show = false);
 
+BR_EXPORT bool br_plot_eer(int num_files, const char *files[], const char *destination, bool show = false);
+
 BR_EXPORT float br_progress();
 
 BR_EXPORT void br_read_pipe(const char *pipe, int *argc, char ***argv);


### PR DESCRIPTION
This PR makes 2 changes to evalEER and adds a new, corresponding, plotEER method. The C API and command line tool are updated to support the new function.

Changes are:

1. Change how operating points are computed to mirror eval (i.e. operating points are added only if both the true positive AND false positive count changes). This fixes a bug where successive operating points could have the same FAR, which caused nan results in the output.

2. Change the optional pdf argument to a CSV argument (again mirroring eval) so that results are written as CSVs and can be combined to show multiple results on the same plot