### PR TITLE
Overlap Change

### DIFF
--- a/openbr/core/eval.cpp
+++ b/openbr/core/eval.cpp
@@ -802,7 +802,7 @@ float EvalDetection(const QString &predictedGallery, const QString &truthGallery
     QRectF normalizations(0, 0, 0, 0);
 
     // Associate predictions to ground truth
-    int totalTrueDetections = associateGroundTruthDetections(resolvedDetections, falseNegativeDetections, allDetections, normalizations);
+    int totalTrueDetections = associateGroundTruthDetections(resolvedDetections, falseNegativeDetections, allDetections, normalizations, truePositiveThreshold);
 
     // Redo association of ground truth to predictions with boundingBoxes
     // resized based on the average differences on each side.
@@ -815,7 +815,7 @@ float EvalDetection(const QString &predictedGallery, const QString &truthGallery
         }
         resolvedDetections.clear();
         falseNegativeDetections.clear();
-        totalTrueDetections = associateGroundTruthDetections(resolvedDetections, falseNegativeDetections, allDetections, normalizations);
+        totalTrueDetections = associateGroundTruthDetections(resolvedDetections, falseNegativeDetections, allDetections, normalizations, truePositiveThreshold);
     }
 
     if (Globals->verbose) {

--- a/openbr/core/evalutils.cpp
+++ b/openbr/core/evalutils.cpp
@@ -160,7 +160,7 @@ QMap<QString, Detections> EvalUtils::filterLabels(const QMap<QString, Detections
     return allFilteredDetections;
 }
 
-int EvalUtils::associateGroundTruthDetections(QList<ResolvedDetection> &resolved, QList<ResolvedDetection> &falseNegative, QMap<QString, Detections> &all, QRectF &offsets)
+int EvalUtils::associateGroundTruthDetections(QList<ResolvedDetection> &resolved, QList<ResolvedDetection> &falseNegative, QMap<QString, Detections> &all, QRectF &offsets, float truePositiveThreshold)
 {
     QList<float> dLeft, dRight, dTop, dBottom;
     int totalTrueDetections = 0;
@@ -191,7 +191,7 @@ int EvalUtils::associateGroundTruthDetections(QList<ResolvedDetection> &resolved
                 const float overlap = truth.overlap(newPredicted);
 
                 if (overlap > 0)
-                    sortedDetections.append(SortedDetection(t, p, overlap));
+                    sortedDetections.append(SortedDetection(t, p, overlap, predicted.confidence, truePositiveThreshold));
             }
         }
 

--- a/openbr/core/evalutils.h
+++ b/openbr/core/evalutils.h
@@ -41,11 +41,16 @@ struct Detection
 struct SortedDetection
 {
     int truth_idx, predicted_idx;
-    float overlap;
-    SortedDetection() : truth_idx(-1), predicted_idx(-1), overlap(-1) {}
-    SortedDetection(int truth_idx_, int predicted_idx_, float overlap_)
-        : truth_idx(truth_idx_), predicted_idx(predicted_idx_), overlap(overlap_) {}
-    inline bool operator<(const SortedDetection &other) const { return overlap > other.overlap; }
+    float overlap, confidence, truePositiveThreshold;
+    SortedDetection() : truth_idx(-1), predicted_idx(-1), overlap(-1), confidence(-1), truePositiveThreshold(-1) {}
+    SortedDetection(int truth_idx_, int predicted_idx_, float overlap_, float confidence_, float truePositiveThreshold_)
+        : truth_idx(truth_idx_), predicted_idx(predicted_idx_), overlap(overlap_), confidence(confidence_), truePositiveThreshold(truePositiveThreshold_) {}
+    inline bool operator<(const SortedDetection &other) const 
+    { 
+        if (overlap >= truePositiveThreshold && other.overlap >= truePositiveThreshold)
+            return confidence > other.confidence;
+        return overlap > other.overlap; 
+    }
 };
 
 struct ResolvedDetection
@@ -106,7 +111,7 @@ struct DetectionOperatingPoint
     QMap<QString, Detections> getDetections(const br::File &predictedGallery, const br::File &truthGallery);
     QMap<QString, Detections> filterDetections(const QMap<QString, Detections> &allDetections, int threshold, bool useMin = true, float relativeThreshold = 0);
     QMap<QString, Detections> filterLabels(const QMap<QString, Detections> &allDetections, const QString &label);
-    int associateGroundTruthDetections(QList<ResolvedDetection> &resolved, QList<ResolvedDetection> &falseNegative, QMap<QString, Detections> &all, QRectF &offsets);
+    int associateGroundTruthDetections(QList<ResolvedDetection> &resolved, QList<ResolvedDetection> &falseNegative, QMap<QString, Detections> &all, QRectF &offsets, float truePositiveThreshold);
     QStringList computeDetectionResults(const QList<ResolvedDetection> &detections, int totalTrueDetections, int numImages, bool discrete, QList<DetectionOperatingPoint> &points, const float truePositiveThreshold);
     inline int getNumberOfImages(const QMap<QString, Detections> detections)
     {


### PR DESCRIPTION
Update sorted detections to take the overlap threshold into account when sorting. Previously, only overlap was used to sort SortedDetections and subsequent assignment of ResolvedDetections was dependent on the overlap ordering. This allowed very low confidence predictions with higher overlap to be assigned to ground truth detections instead of higher confidence predictions with slightly worse overlap. The new methodology is to sort by overlap up to the overlap threshold, but then switch to sorting by confidence.