### PR TITLE
Move `-Wno-terminate` compiler flag to GCC only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,9 +135,10 @@ endif()
 
 # Compiler flags
 if(UNIX)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-strict-overflow -Wno-terminate -Wno-sign-compare -Wno-unused-local-typedefs -Wno-int-in-bool-context -Wno-comment -Wno-unknown-pragmas -fvisibility=hidden -fno-omit-frame-pointer")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-strict-overflow -Wno-sign-compare -Wno-unused-local-typedefs -Wno-int-in-bool-context -Wno-comment -Wno-unknown-pragmas -fvisibility=hidden -fno-omit-frame-pointer")
   set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib ${_qt5Core_install_prefix}/lib)
   if(NOT APPLE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-terminate")
     if(${CMAKE_CXX_COMPILER} STREQUAL "/opt/intel/bin/icpc")
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-intel -wd2196")
     endif()


### PR DESCRIPTION
Avoids warning on macOS/Apple clang