### PR TITLE
Add the ability for evalDetection to handle background images (images…

### DIFF
--- a/openbr/core/eval.cpp
+++ b/openbr/core/eval.cpp
@@ -809,6 +809,25 @@ float EvalDetection(const QString &predictedGallery, const QString &truthGallery
     // Organized by file, QMap used to preserve order
     QMap<QString, Detections> allDetections = getDetections(predictedGallery, truthGallery);
 
+    // Ensure there is at least some overlap between truth and pred, otherwise we expect a path issue
+    int truthOnly = 0, predOnly = 0, bothTruthAndPred = 0;
+    foreach (QString key, allDetections.keys()) {
+        if (allDetections[key].truth.isEmpty())
+            predOnly += 1;
+        else if (allDetections[key].predicted.isEmpty())
+            truthOnly += 1;
+        else
+            bothTruthAndPred += 1;
+    }
+
+    if (bothTruthAndPred == 0)
+        qFatal("No files have both truth and predicted detections. Check your file paths and try again");
+
+    qDebug() << "File count -> Total:" << allDetections.size();
+    qDebug() << "  Truth only:" << truthOnly;
+    qDebug() << "  Predicted only:" << predOnly;
+    qDebug() << "  Both:" << bothTruthAndPred;
+
     // Remove any bounding boxes with a side smaller than minSize
     if (minSize > 0 || relativeMinSize > 0) {
         if (Globals->verbose)

--- a/openbr/core/evalutils.cpp
+++ b/openbr/core/evalutils.cpp
@@ -108,8 +108,7 @@ QMap<QString, Detections> EvalUtils::getDetections(const File &predictedGallery,
         allDetections[f.name].imageSize = QSize(image.cols, image.rows);
     }
     foreach (const File &f, predicted)
-        if (allDetections.contains(f.name))
-            allDetections[f.name].predicted.append(getDetections(predictedDetectKey, f, false));
+        allDetections[f.name].predicted.append(getDetections(predictedDetectKey, f, false));
     return allDetections;
 }
 


### PR DESCRIPTION
… with no groundtruth detection). Add an error if no files in evalDetection have both truth and predicted detections (previously would just segfault)