### PR TITLE
update QTime to QElapsedTimer

### DIFF
--- a/openbr/core/boost.cpp
+++ b/openbr/core/boost.cpp
@@ -751,7 +751,7 @@ void CascadeBoostTrainData::precalculate()
 
     qDebug() << "Starting precalculation...";
 
-    QTime time;
+    QElapsedTimer time;
     time.start();
 
     // Compute features and sort training samples for feature indices we are not going to cache

--- a/openbr/openbr_plugin.h
+++ b/openbr/openbr_plugin.h
@@ -36,7 +36,7 @@
 #include <QString>
 #include <QStringList>
 #include <QThread>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QVariant>
 #include <QVector>
 #include <opencv2/core.hpp>
@@ -526,7 +526,7 @@ public:
     BR_PROPERTY(QList<QString>, modelSearch, QList<QString>() )
 
     QHash<QString,QString> abbreviations;
-    QTime startTime;
+    QElapsedTimer startTime;
 
     bool contains(const QString &name);
     void printStatus();

--- a/openbr/plugins/metadata/stopwatch.cpp
+++ b/openbr/plugins/metadata/stopwatch.cpp
@@ -60,7 +60,7 @@ private:
 
     void train(const QList<TemplateList> &data)
     {
-        QTime watch;
+        QElapsedTimer watch;
         watch.start();
 
         transform->train(data);
@@ -80,7 +80,7 @@ private:
 
     void project(const Template &src, Template &dst) const
     {
-        QTime watch;
+        QElapsedTimer watch;
         watch.start();
         transform->project(src, dst);
 


### PR DESCRIPTION
QTime `elapsed()` is deprecated, updating to QElapsedTimer is recommended.  `QElapsedTimer` was added in Qt v4.7.

 