### PR TITLE
Update QtUtils fromString conversion from float to double

### DIFF
--- a/openbr/core/qtutils.cpp
+++ b/openbr/core/qtutils.cpp
@@ -538,8 +538,8 @@ QVariant fromString(const QString &value)
     if (ok) return QVariant::fromValue(rotatedRect);
     const int i = value.toInt(&ok);
     if (ok) return i;
-    const float f = value.toFloat(&ok);
-    if (ok) return f;
+    const double d = value.toDouble(&ok);
+    if (ok) return d;
     const bool b = QtUtils::toBool(value, &ok);
     if (ok) return b;
     return value;


### PR DESCRIPTION
The `toFloat` conversion can result in loss of precision as well as erroneous conversion of strings -> floats -> strings in certain cases. Using `toDouble` should address this. 